### PR TITLE
Aml parser

### DIFF
--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -30,6 +30,7 @@ SECTIONS {
     .data :
     {
         KEEP(*(.boot_page_tables .boot_page_tables.*))
+        KEEP(*(.stack .stack.*))
         *(.data .data.*)
     } : kernel_rw
 

--- a/kernel/src/acpi/mod.rs
+++ b/kernel/src/acpi/mod.rs
@@ -1,3 +1,4 @@
+mod aml;
 pub mod tables;
 
 pub use tables::get_acpi_tables;

--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -597,7 +597,12 @@ impl fmt::Display for BiosTables {
         writeln!(f, "RSDP: {:#X?}", self.rsdp)?;
         writeln!(f, "RSDT: {:#X?}", self.rsdt.header)?;
         for entry in &self.rsdt.entries {
-            writeln!(f, "{:X?}", entry.body)?;
+            if let DescriptorTableBody::Dsdt(entry) = &entry.body {
+                writeln!(f, "DSDT: ")?;
+                entry.aml_code.display_with_depth(f, 1)?;
+            } else {
+                writeln!(f, "{:X?}", entry.body)?;
+            }
         }
         Ok(())
     }

--- a/kernel/src/boot.S
+++ b/kernel/src/boot.S
@@ -27,6 +27,8 @@ PHY_PAGE_SIZE_4K = 0x1000
 PHY_PAGE_SIZE_2M = 0x200000
 PAGE_TABLE_ALLOC_PAGES = 4  # only need 4
 
+STACK_SIZE_PAGES = 128
+
 # Page tables flags
 PGE_PRESENT   = 1 << 0
 PGE_WRITE     = 1 << 1
@@ -275,8 +277,8 @@ kernel_main_low:
     mov gs, ax
     mov ss, ax
 
-    # setup the stack (grows downwards to 0x00000000, which gets us 64KB of stack)
-    mov rax, 0xFFFFFFFF80010000
+    # setup the stack (grows downwards to stack_guard_page)
+    mov rax, offset stack_end - 8
     mov rsp, rax
 
     # (first argument) rdi = multiboot info (we haven't toched ebx, so it should have the same value since `entry`)
@@ -292,3 +294,13 @@ kernel_main_low:
 .align PHY_PAGE_SIZE_4K
 boot_page_tables:
     .space PHY_PAGE_SIZE_4K * PAGE_TABLE_ALLOC_PAGES, 0
+
+.section .stack
+.align PHY_PAGE_SIZE_4K
+.global stack_guard_page
+stack_guard_page:
+    .space PHY_PAGE_SIZE_4K, 0
+.align PHY_PAGE_SIZE_4K
+stack:
+    .space PHY_PAGE_SIZE_4K * STACK_SIZE_PAGES, 0
+stack_end:

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -7,6 +7,7 @@ extern "C" {
     static begin: usize;
     static end: usize;
     static rodata_end: usize;
+    static stack_guard_page: usize;
 }
 
 // it starts at 0x10000, which is where the kernel is loaded, and grows down
@@ -71,6 +72,10 @@ pub fn kernel_elf_size() -> usize {
 
 pub fn kernel_elf_rodata_end() -> usize {
     (unsafe { &rodata_end } as *const usize as usize)
+}
+
+pub fn stack_guard_page_ptr() -> usize {
+    (unsafe { &stack_guard_page } as *const usize as usize)
 }
 
 pub const fn align_up(addr: usize, alignment: usize) -> usize {


### PR DESCRIPTION
Fixes #5 

This just parses the `AML` code, and not the full set of commands, but this can parse the `AML` code we got from `qemu`.