### PR TITLE
Aqdded dynamic `virtual_space` allocator

### DIFF
--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -25,11 +25,7 @@ fn physical_to_acpi_memory(addr: usize, size: usize) -> usize {
         assert!(addr + size <= virtual2physical(KERNEL_END));
         addr + KERNEL_BASE
     } else {
-        let phy_start = align_down(addr, PAGE_4K);
-        let offset = addr - phy_start;
-        virtual_space::get_virtual_for_physical(phy_start as _, align_up(size, PAGE_4K) as _)
-            as usize
-            + offset
+        virtual_space::get_virtual_for_physical(addr as _, size as _) as usize
     }
 }
 

--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -8,7 +8,7 @@ use crate::{
             align_down, allocate_from_extra_kernel_pages, virtual2physical, KERNEL_BASE,
             KERNEL_END, PAGE_4K,
         },
-        virtual_memory::{self, VirtualMemoryMapEntry},
+        virtual_memory_mapper::{self, VirtualMemoryMapEntry},
     },
     multiboot2::MultiBoot2Info,
     sync::once::OnceLock,
@@ -60,7 +60,7 @@ impl BiosMemoryMapper {
 
         let start_virtual = unsafe { allocate_from_extra_kernel_pages(num_pages) };
 
-        virtual_memory::map_kernel(&VirtualMemoryMapEntry {
+        virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
             virtual_address: start_virtual as u64,
             physical_address: Some(physical_start),
             size: num_pages as u64 * PAGE_4K as u64,

--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -1,17 +1,18 @@
-use core::{any::Any, fmt, mem::size_of, slice};
+use core::{
+    any::Any,
+    fmt,
+    mem::{self, size_of},
+    slice,
+};
 
 use alloc::{boxed::Box, vec::Vec};
 
 use crate::{
     memory_management::{
-        memory_layout::{
-            align_down, allocate_from_extra_kernel_pages, virtual2physical, KERNEL_BASE,
-            KERNEL_END, PAGE_4K,
-        },
-        virtual_memory_mapper::{self, VirtualMemoryMapEntry},
+        memory_layout::{align_down, align_up, virtual2physical, KERNEL_BASE, KERNEL_END, PAGE_4K},
+        virtual_space,
     },
     multiboot2::MultiBoot2Info,
-    sync::once::OnceLock,
 };
 
 use super::aml::{parse_aml, AmlCode};
@@ -19,76 +20,31 @@ use super::aml::{parse_aml, AmlCode};
 const BIOS_RO_MEM_START: usize = 0x000E0000;
 const BIOS_RO_MEM_END: usize = 0x000FFFFF;
 
-static BIOS_MEMORY_MAPPER: OnceLock<BiosMemoryMapper> = OnceLock::new();
-
-fn physical_to_bios_memory(addr: usize) -> usize {
+fn physical_to_acpi_memory(addr: usize, size: usize) -> usize {
     if addr < virtual2physical(KERNEL_END) {
+        assert!(addr + size <= virtual2physical(KERNEL_END));
         addr + KERNEL_BASE
-    } else if let Some(mapper) = BIOS_MEMORY_MAPPER.try_get() {
-        mapper.get_virtual(addr as _) as _
     } else {
-        let mapper = BiosMemoryMapper::new(addr as _);
-        let virtual_addr = mapper.get_virtual(addr as _) as _;
-        BIOS_MEMORY_MAPPER
-            .set(mapper)
-            .expect("BIOS_MEMORY_MAPPER already set");
-        virtual_addr
+        let phy_start = align_down(addr, PAGE_4K);
+        let offset = addr - phy_start;
+        virtual_space::get_virtual_for_physical(phy_start as _, align_up(size, PAGE_4K) as _)
+            as usize
+            + offset
     }
 }
 
-// number of pages to map around the `prope/start` address
-// TODO: replace by mapping whole memory segments (normally are not large)
-const BIOS_MEMORY_MAPPED_PAGES_AROUND: usize = 10;
-
-#[derive(Debug)]
-struct BiosMemoryMapper {
-    start_physical: u64,
-    start_virtual: u64,
-    num_pages: usize,
-}
-
-impl BiosMemoryMapper {
-    // we use `prope_addr` to know where to start from, generally this memory isn't very large
-    // so we can just start pages around `prope` address and map from there
-    pub fn new(prope_addr: u64) -> Self {
-        let prope_page = align_down(prope_addr as _, PAGE_4K) as u64;
-        const MEMORY_AROUND: u64 = BIOS_MEMORY_MAPPED_PAGES_AROUND as u64 * PAGE_4K as u64;
-        assert!(prope_page > MEMORY_AROUND);
-        assert!(prope_page < (usize::MAX as u64 - MEMORY_AROUND));
-        let physical_start = prope_page - MEMORY_AROUND;
-        let num_pages = BIOS_MEMORY_MAPPED_PAGES_AROUND * 2 + 1;
-
-        let start_virtual = unsafe { allocate_from_extra_kernel_pages(num_pages) };
-
-        virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
-            virtual_address: start_virtual as u64,
-            physical_address: Some(physical_start),
-            size: num_pages as u64 * PAGE_4K as u64,
-            flags: 0,
-        });
-
-        Self {
-            start_physical: physical_start,
-            start_virtual: start_virtual as u64,
-            num_pages,
-        }
-    }
-
-    pub fn get_virtual(&self, addr: u64) -> u64 {
-        if addr >= self.start_physical
-            && addr < self.start_physical + self.num_pages as u64 * PAGE_4K as u64
-        {
-            addr - self.start_physical + self.start_virtual
-        } else {
-            // for now I'm assuming we can start from the first address we try to map
-            // and just map `BIOS_MEMORY_MAPPED_PAGES_AROUND` pages around it
-            panic!(
-                "bios address {:#X} not mapped, range: {:#X}-{:#X}",
-                addr,
-                self.start_physical,
-                self.start_physical + self.num_pages as u64 * PAGE_4K as u64
-            );
-        }
+// this is used after parsing headers and determining the size of the table
+// it tells the `virtual_space` module to ensure that the new size is still
+// mapped, otherwise try to allocate next blocks if they are free.
+// in our case since its done immidiately after parsing the headers, we know it
+// should work unless someone else is executing concurrently
+// at the time of writing this comment, this is done in startup so there shouldn't be anyne else.
+fn ensure_at_least_size(addr: usize, size: usize) {
+    if addr < virtual2physical(KERNEL_END) {
+        assert!(addr + size <= virtual2physical(KERNEL_END));
+    } else {
+        let virtual_start = align_down(addr, PAGE_4K);
+        virtual_space::ensure_at_least_size(virtual_start as _, align_up(size, PAGE_4K) as _);
     }
 }
 
@@ -98,8 +54,9 @@ pub fn get_acpi_tables(multiboot_info: &MultiBoot2Info) -> Result<BiosTables, ()
         .get_most_recent_rsdp()
         .or_else(|| {
             // look for RSDP PTR
-            let mut rsdp_ptr = physical_to_bios_memory(BIOS_RO_MEM_START) as *const u8;
-            let end = physical_to_bios_memory(BIOS_RO_MEM_END) as *const u8;
+            let mut rsdp_ptr =
+                physical_to_acpi_memory(BIOS_RO_MEM_START, mem::size_of::<Rsdp>()) as *const u8;
+            let end = physical_to_acpi_memory(BIOS_RO_MEM_END, mem::size_of::<Rsdp>()) as *const u8;
 
             while rsdp_ptr < end {
                 let str = unsafe { slice::from_raw_parts(rsdp_ptr, 8) };
@@ -195,8 +152,12 @@ impl Rsdp {
 
     // allocates a new RDST
     fn rdst(&self) -> Rsdt {
-        let header = physical_to_bios_memory(self.rsdt_address as _) as *const DescriptionHeader;
+        let header =
+            physical_to_acpi_memory(self.rsdt_address as _, mem::size_of::<DescriptionHeader>())
+                as *const DescriptionHeader;
         let len = unsafe { (*header).length } as usize;
+        ensure_at_least_size(header as _, len);
+
         let entries_len = (len - size_of::<DescriptionHeader>()) / size_of::<u32>();
         let entries_ptr = unsafe { header.add(1) as *const u32 };
         // use slice of u8 since we can't use u32 since its not aligned
@@ -271,7 +232,15 @@ pub struct DescriptorTable {
 
 impl DescriptorTable {
     pub fn from_physical_ptr(ptr: u32) -> Self {
-        let header = unsafe { &*(physical_to_bios_memory(ptr as _) as *const DescriptionHeader) };
+        let header = unsafe {
+            &*(physical_to_acpi_memory(ptr as _, mem::size_of::<DescriptionHeader>())
+                as *const DescriptionHeader)
+        };
+        ensure_at_least_size(
+            header as *const DescriptionHeader as _,
+            header.length as usize,
+        );
+
         let body = match &header.signature {
             b"APIC" => DescriptorTableBody::Apic(Box::new(Apic::from_header(header))),
             b"FACP" => DescriptorTableBody::Facp(Box::new(Facp::from_header(header))),

--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -636,12 +636,13 @@ impl BiosTables {
 
 impl fmt::Display for BiosTables {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "RSDP: {:#X?}", self.rsdp)?;
-        writeln!(f, "RSDT: {:#X?}", self.rsdt.header)?;
+        writeln!(f, "RSDP: {:X?}", self.rsdp)?;
+        writeln!(f, "RSDT: {:X?}", self.rsdt.header)?;
         for entry in &self.rsdt.entries {
-            if let DescriptorTableBody::Dsdt(entry) = &entry.body {
-                writeln!(f, "DSDT: ")?;
-                entry.aml_code.display_with_depth(f, 1)?;
+            if let DescriptorTableBody::Dsdt(_entry) = &entry.body {
+                // TODO: add cmdline arg to print DSDT (its very large, so don't by default)
+                // writeln!(f, "DSDT: ")?;
+                // entry.aml_code.display_with_depth(f, 1)?;
             } else {
                 writeln!(f, "{:X?}", entry.body)?;
             }

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -6,7 +6,7 @@ use crate::{
             is_aligned, INTR_STACK_BASE, INTR_STACK_EMPTY_SIZE, INTR_STACK_ENTRY_SIZE,
             INTR_STACK_SIZE, INTR_STACK_TOTAL_SIZE, KERNEL_STACK_END, PAGE_4K,
         },
-        virtual_memory::{self, VirtualMemoryMapEntry},
+        virtual_memory_mapper::{self, VirtualMemoryMapEntry},
     },
     sync::spin::mutex::Mutex,
 };
@@ -85,11 +85,11 @@ pub fn init_kernel_gdt() {
             );
 
             // map the stack
-            virtual_memory::map_kernel(&VirtualMemoryMapEntry {
+            virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
                 virtual_address: stack_start_virtual as u64,
                 physical_address: None,
                 size: INTR_STACK_SIZE as u64,
-                flags: virtual_memory::flags::PTE_WRITABLE,
+                flags: virtual_memory_mapper::flags::PTE_WRITABLE,
             });
 
             // set the stack pointer

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -279,6 +279,10 @@ pub unsafe fn halt() {
     core::arch::asm!("hlt", options(nomem, nostack, preserves_flags));
 }
 
+pub unsafe fn invalidate_tlp(virtual_address: u64) {
+    core::arch::asm!("invlpg [{0}]", in(reg) virtual_address);
+}
+
 #[macro_export]
 macro_rules! cpuid {
     ($rax:expr) => {

--- a/kernel/src/executable/elf.rs
+++ b/kernel/src/executable/elf.rs
@@ -2,7 +2,7 @@ use core::{fmt, mem};
 
 use alloc::vec::Vec;
 
-use crate::{fs, memory_management::virtual_memory};
+use crate::{fs, memory_management::virtual_memory_mapper};
 
 #[derive(Debug)]
 pub enum ElfLoadError {
@@ -45,7 +45,7 @@ pub fn to_virtual_memory_flags(flags: u32) -> u64 {
     let mut vm_flags = 0;
 
     if flags & consts::PROG_FLAG_WRITE != 0 {
-        vm_flags |= virtual_memory::flags::PTE_WRITABLE;
+        vm_flags |= virtual_memory_mapper::flags::PTE_WRITABLE;
     }
     if flags & consts::PROG_FLAG_EXE != 0 {
         // TODO: add support for executable pages

--- a/kernel/src/executable/mod.rs
+++ b/kernel/src/executable/mod.rs
@@ -1,4 +1,4 @@
-use crate::{fs, memory_management::virtual_memory};
+use crate::{fs, memory_management::virtual_memory_mapper};
 
 pub mod elf;
 
@@ -6,9 +6,9 @@ pub mod elf;
 pub fn load_elf_to_vm(
     elf: &elf::Elf,
     file: &mut fs::File,
-    vm: &mut virtual_memory::VirtualMemoryManager,
+    vm: &mut virtual_memory_mapper::VirtualMemoryMapper,
 ) -> Result<(), fs::FileSystemError> {
-    let old_vm = virtual_memory::get_current_vm();
+    let old_vm = virtual_memory_mapper::get_current_vm();
 
     // switch temporaily so we can map the elf
     vm.switch_to_this();
@@ -17,8 +17,8 @@ pub fn load_elf_to_vm(
         if let elf::ElfProgramType::Load = segment.ty() {
             assert!(segment.virtual_address() == segment.physical_address());
             let mut flags = elf::to_virtual_memory_flags(segment.flags());
-            flags |= virtual_memory::flags::PTE_USER;
-            let entry = virtual_memory::VirtualMemoryMapEntry {
+            flags |= virtual_memory_mapper::flags::PTE_USER;
+            let entry = virtual_memory_mapper::VirtualMemoryMapEntry {
                 virtual_address: segment.virtual_address(),
                 physical_address: None,
                 size: segment.mem_size(),

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 #![feature(abi_x86_interrupt)]
+#![feature(linked_list_cursors)]
 
 extern crate alloc;
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -33,7 +33,7 @@ use cpu::{
 };
 use executable::elf::Elf;
 use io::console;
-use memory_management::virtual_memory;
+use memory_management::virtual_memory_mapper;
 use multiboot2::MultiBoot2Info;
 use process::scheduler;
 
@@ -103,7 +103,7 @@ pub extern "C" fn kernel_main(multiboot_info: &MultiBoot2Info) -> ! {
     // must be called before any pages can be allocated
     physical_page_allocator::init(multiboot_info);
     // must be called next, before GDT, and this must be called before any heap allocations
-    virtual_memory::init_kernel_vm();
+    virtual_memory_mapper::init_kernel_vm();
     // must be called before interrupts
     gdt::init_kernel_gdt();
     interrupts::init_interrupts();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -41,7 +41,7 @@ use crate::{
     devices::clock,
     memory_management::{
         kernel_heap_allocator::ALLOCATOR,
-        memory_layout::{MemSize, KERNEL_HEAP_SIZE, PAGE_4K},
+        memory_layout::{self, MemSize, KERNEL_HEAP_SIZE, PAGE_4K},
         physical_page_allocator,
     },
     process::Process,
@@ -55,6 +55,7 @@ fn finish_boot() {
     //  but then it got freed we don't record that
     let (free_heap, used_heap) = ALLOCATOR.stats();
     println!("\n\nBoot finished!");
+    memory_layout::display_kernel_map();
     println!("Free memory: {}", free_mem);
     println!(
         "Used memory: {} ({:0.3}%)",

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -43,7 +43,7 @@ use crate::{
     memory_management::{
         kernel_heap_allocator::ALLOCATOR,
         memory_layout::{self, MemSize, KERNEL_HEAP_SIZE, PAGE_4K},
-        physical_page_allocator,
+        physical_page_allocator, virtual_space,
     },
     process::Process,
 };
@@ -74,6 +74,7 @@ fn finish_boot() {
         MemSize(KERNEL_HEAP_SIZE as u64),
         used_heap as f64 / KERNEL_HEAP_SIZE as f64 * 100.
     );
+    virtual_space::debug_blocks();
     println!();
 }
 

--- a/kernel/src/memory_management/kernel_heap_allocator.rs
+++ b/kernel/src/memory_management/kernel_heap_allocator.rs
@@ -3,7 +3,7 @@ use core::{alloc::GlobalAlloc, mem};
 use crate::{
     memory_management::{
         memory_layout::{is_aligned, KERNEL_HEAP_SIZE},
-        virtual_memory::{self, flags, VirtualMemoryMapEntry},
+        virtual_memory_mapper::{self, flags, VirtualMemoryMapEntry},
     },
     sync::spin::mutex::Mutex,
 };
@@ -193,7 +193,7 @@ impl KernelHeapAllocator {
         // do not exceed the heap size
         assert!((self.mapped_pages + pages) * PAGE_4K <= KERNEL_HEAP_SIZE);
 
-        virtual_memory::map_kernel(&VirtualMemoryMapEntry {
+        virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
             virtual_address: current_heap_base as u64,
             physical_address: None,
             size: (PAGE_4K * pages) as u64,

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -96,6 +96,18 @@ pub fn is_aligned(addr: usize, alignment: usize) -> bool {
     (addr & (alignment - 1)) == 0
 }
 
+pub fn align_range(addr: usize, size: usize, alignment: usize) -> (usize, usize, usize) {
+    let addr_end: usize = addr + size;
+    let start_aligned = align_down(addr, alignment);
+    let end_aligned = align_up(addr_end, alignment);
+    let size = end_aligned - start_aligned;
+    assert!(size > 0);
+    assert!(is_aligned(size, alignment));
+    let offset = addr - start_aligned;
+
+    (start_aligned, size, offset)
+}
+
 #[inline(always)]
 pub const fn virtual2physical(addr: usize) -> usize {
     addr - KERNEL_BASE

--- a/kernel/src/memory_management/mod.rs
+++ b/kernel/src/memory_management/mod.rs
@@ -1,4 +1,4 @@
 pub mod kernel_heap_allocator;
 pub mod memory_layout;
 pub mod physical_page_allocator;
-pub mod virtual_memory;
+pub mod virtual_memory_mapper;

--- a/kernel/src/memory_management/mod.rs
+++ b/kernel/src/memory_management/mod.rs
@@ -2,3 +2,4 @@ pub mod kernel_heap_allocator;
 pub mod memory_layout;
 pub mod physical_page_allocator;
 pub mod virtual_memory_mapper;
+pub mod virtual_space;

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -116,11 +116,11 @@ impl PageDirectoryTablePtr {
     }
 }
 
-static KERNEL_VIRTUAL_MEMORY_MANAGER: Mutex<VirtualMemoryManager> =
-    Mutex::new(VirtualMemoryManager::boot_vm());
+static KERNEL_VIRTUAL_MEMORY_MANAGER: Mutex<VirtualMemoryMapper> =
+    Mutex::new(VirtualMemoryMapper::boot_vm());
 
 pub fn init_kernel_vm() {
-    let new_kernel_manager = VirtualMemoryManager::new_kernel_vm();
+    let new_kernel_manager = VirtualMemoryMapper::new_kernel_vm();
     let mut manager = KERNEL_VIRTUAL_MEMORY_MANAGER.lock();
     *manager = new_kernel_manager;
     manager.switch_to_this();
@@ -129,7 +129,7 @@ pub fn init_kernel_vm() {
     map_device_memory(&mut manager);
 }
 
-fn map_device_memory(manager: &mut VirtualMemoryManager) {
+fn map_device_memory(manager: &mut VirtualMemoryMapper) {
     let map_entry = VirtualMemoryMapEntry {
         virtual_address: DEVICE_BASE_VIRTUAL as u64,
         physical_address: Some(DEVICE_BASE_PHYSICAL as u64),
@@ -157,23 +157,23 @@ pub fn is_address_mapped_in_kernel(addr: u64) -> bool {
 }
 
 #[allow(dead_code)]
-pub fn clone_kernel_vm_as_user() -> VirtualMemoryManager {
+pub fn clone_kernel_vm_as_user() -> VirtualMemoryMapper {
     let manager = KERNEL_VIRTUAL_MEMORY_MANAGER.lock();
     let mut new_vm = manager.clone_kernel_mem();
     new_vm.is_user = true;
     new_vm
 }
 
-pub fn get_current_vm() -> VirtualMemoryManager {
-    VirtualMemoryManager::get_current_vm()
+pub fn get_current_vm() -> VirtualMemoryMapper {
+    VirtualMemoryMapper::get_current_vm()
 }
 
-pub struct VirtualMemoryManager {
+pub struct VirtualMemoryMapper {
     page_map_l4: PageDirectoryTablePtr,
     is_user: bool,
 }
 
-impl VirtualMemoryManager {
+impl VirtualMemoryMapper {
     /// Return the VM for the CPU at boot time (only applied to the first CPU and this is setup in `boot.S`)
     const fn boot_vm() -> Self {
         Self {

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -151,6 +151,18 @@ pub fn map_kernel(entry: &VirtualMemoryMapEntry) {
     KERNEL_VIRTUAL_MEMORY_MANAGER.lock().map(entry);
 }
 
+/// `is_allocated` is used to indicate if the physical pages were allocated by the caller
+/// i.e. when we called `map_kernel`, the `physical_address` is `None` and we will allocate the pages, and thus
+/// when calling this function, you should pass `is_allocated = true`
+// TODO: maybe its better to keep track of this information somewhere in the mapper here
+pub fn unmap_kernel(entry: &VirtualMemoryMapEntry, is_allocated: bool) {
+    // make sure we are only mapping to kernel memory
+    assert!(entry.virtual_address >= KERNEL_BASE as u64);
+    KERNEL_VIRTUAL_MEMORY_MANAGER
+        .lock()
+        .unmap_impl(entry, is_allocated);
+}
+
 #[allow(dead_code)]
 pub fn is_address_mapped_in_kernel(addr: u64) -> bool {
     KERNEL_VIRTUAL_MEMORY_MANAGER.lock().is_address_mapped(addr)

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -494,6 +494,10 @@ impl VirtualMemoryMapper {
         );
 
         while size > 0 {
+            unsafe {
+                cpu::invalidate_tlp(virtual_address as _);
+            }
+
             let page_map_l4_index = get_l4(virtual_address) as usize;
             let page_directory_pointer_index = get_l3(virtual_address) as usize;
             let page_directory_index = get_l2(virtual_address) as usize;

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -123,20 +123,6 @@ pub fn init_kernel_vm() {
     let mut manager = KERNEL_VIRTUAL_MEMORY_MANAGER.lock();
     *manager = new_kernel_manager;
     manager.switch_to_this();
-
-    // map the BIOS memory
-    map_device_memory(&mut manager);
-}
-
-fn map_device_memory(manager: &mut VirtualMemoryMapper) {
-    let map_entry = VirtualMemoryMapEntry {
-        virtual_address: DEVICE_BASE_VIRTUAL as u64,
-        physical_address: Some(DEVICE_BASE_PHYSICAL as u64),
-        size: DEVICE_PHYSICAL_END as u64 - DEVICE_BASE_PHYSICAL as u64,
-        flags: flags::PTE_WRITABLE,
-    };
-
-    manager.map(&map_entry);
 }
 
 #[allow(dead_code)]

--- a/kernel/src/memory_management/virtual_space.rs
+++ b/kernel/src/memory_management/virtual_space.rs
@@ -1,0 +1,296 @@
+use alloc::collections::LinkedList;
+
+use crate::{
+    memory_management::memory_layout::{
+        is_aligned, KERNEL_EXTRA_MEMORY_BASE, KERNEL_EXTRA_MEMORY_SIZE, PAGE_4K,
+    },
+    sync::spin::mutex::Mutex,
+};
+
+use super::virtual_memory_mapper::{self, VirtualMemoryMapEntry};
+
+static VIRTUAL_SPACE_ALLOCATOR: Mutex<VirtualSpaceAllocator> =
+    Mutex::new(VirtualSpaceAllocator::empty());
+
+pub fn get_virtual_for_physical(physical_start: u64, size: u64) -> u64 {
+    let mut allocator = VIRTUAL_SPACE_ALLOCATOR.lock();
+    let virtual_addr = allocator.get_virtual_for_physical(physical_start, size);
+    // ensure its mapped
+    virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
+        virtual_address: virtual_addr,
+        physical_address: Some(physical_start),
+        size,
+        flags: virtual_memory_mapper::flags::PTE_WRITABLE,
+    });
+    // to make sure no one else play around with the space while we are mapping it
+    drop(allocator);
+
+    virtual_addr
+}
+
+pub fn ensure_at_least_size(virtual_start: u64, size: u64) {
+    let mut allocator = VIRTUAL_SPACE_ALLOCATOR.lock();
+    if let Some((allocated, physical_addr)) = allocator.ensure_at_least_size(virtual_start, size) {
+        if allocated {
+            // ensure its mapped
+            virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
+                virtual_address: virtual_start,
+                physical_address: Some(physical_addr),
+                size,
+                flags: virtual_memory_mapper::flags::PTE_WRITABLE,
+            });
+        }
+    } else {
+        panic!("Could not ensure at least size")
+    }
+    drop(allocator);
+}
+
+#[allow(dead_code)]
+pub fn allocate_and_map_virtual_space(physical_start: u64, size: u64) -> u64 {
+    let mut allocator = VIRTUAL_SPACE_ALLOCATOR.lock();
+    let virtual_addr = allocator.allocate(physical_start, size);
+
+    virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
+        virtual_address: virtual_addr,
+        physical_address: Some(physical_start),
+        size,
+        flags: virtual_memory_mapper::flags::PTE_WRITABLE,
+    });
+    // to make sure no one else play around with the space while we are mapping it
+    drop(allocator);
+
+    virtual_addr
+}
+
+#[allow(dead_code)]
+pub fn deallocate_virtual_space(virtual_start: u64, size: u64) {
+    let mut allocator = VIRTUAL_SPACE_ALLOCATOR.lock();
+
+    // unmap it
+    virtual_memory_mapper::unmap_kernel(
+        &VirtualMemoryMapEntry {
+            virtual_address: virtual_start,
+            physical_address: None,
+            size,
+            flags: virtual_memory_mapper::flags::PTE_WRITABLE,
+        },
+        // we did specify our own physical address on allocation, so we must set this to false
+        false,
+    );
+    allocator.deallocate(virtual_start, size)
+}
+
+struct VirtualSpaceEntry {
+    physical_start: Option<u64>,
+    virtual_start: u64,
+    size: u64,
+}
+
+struct VirtualSpaceAllocator {
+    entries: LinkedList<VirtualSpaceEntry>,
+}
+
+impl VirtualSpaceAllocator {
+    const fn empty() -> Self {
+        Self {
+            entries: LinkedList::new(),
+        }
+    }
+
+    /// Checks if we have this range allocated, returns it, otherwise perform an allocation, map it, and return
+    /// the new address
+    fn get_virtual_for_physical(&mut self, req_phy_start: u64, req_size: u64) -> u64 {
+        assert!(req_size > 0);
+        assert!(is_aligned(req_phy_start as _, PAGE_4K));
+        assert!(is_aligned(req_size as _, PAGE_4K));
+
+        let mut cursor = self.entries.cursor_front();
+        while let Some(entry) = cursor.current() {
+            if let Some(current_phy_start) = entry.physical_start {
+                // is inside?
+                if current_phy_start <= req_phy_start
+                    && current_phy_start + entry.size > req_phy_start
+                {
+                    // this has parts of it inside
+                    // is it fully inside?
+                    if current_phy_start + entry.size >= req_phy_start + req_size {
+                        // yes, it is fully inside
+                        return entry.virtual_start + req_phy_start - current_phy_start;
+                    } else {
+                        // no, it is not fully inside, but there is an overlap
+                        // we can't allocate this and we can't relocate
+                        panic!("Requested {:016X}..{:016X} is inside {:016X}..{:016X} but it is not fully inside, and we can't relocate it", 
+                            req_phy_start, req_phy_start + req_size, current_phy_start, current_phy_start + entry.size);
+                    }
+                }
+            }
+            cursor.move_next();
+        }
+        // we didn't find it, allocate it
+        self.allocate(req_phy_start, req_size)
+    }
+
+    // Returns `Some` if it ensures the space
+    // Returns `None` if it can't ensure the space
+    //  Return true if it needs to be mapped, i.e. allocated
+    //  Return false if it is already allocated
+    fn ensure_at_least_size(
+        &mut self,
+        req_virtual_start: u64,
+        req_size: u64,
+    ) -> Option<(bool, u64)> {
+        assert!(req_size > 0);
+        assert!(is_aligned(req_virtual_start as _, PAGE_4K));
+        assert!(is_aligned(req_size as _, PAGE_4K));
+
+        let mut cursor = self.entries.cursor_front_mut();
+        while let Some(entry) = cursor.current() {
+            let entry_virtual_end = entry.virtual_start + entry.size;
+            // is inside?
+            if entry.virtual_start <= req_virtual_start && entry_virtual_end > req_virtual_start {
+                let Some(current_phy_start) = entry.physical_start else {
+                    // it is not allocated
+                    panic!(
+                        "Could not ensure size for {:016X}..{:016X}, it is not allocated",
+                        req_virtual_start,
+                        req_virtual_start + req_size
+                    );
+                };
+                // get the offset from the start of this block
+                let virt_offset = req_virtual_start - entry.virtual_start;
+                // this has parts of it inside
+                // is it fully inside?
+                if entry_virtual_end >= req_virtual_start + req_size {
+                    // yes, it is fully inside
+                    return Some((false, current_phy_start + virt_offset));
+                } else {
+                    let addition_size = (req_virtual_start + req_size) - entry_virtual_end;
+                    assert!(addition_size > 0);
+                    let new_size = entry.size + addition_size;
+                    // try to allocate from the next entry only if it is not allocated
+                    let current = cursor.remove_current().unwrap();
+                    if let Some(next_entry) = cursor.current() {
+                        if next_entry.physical_start.is_none() {
+                            // next is not taken, take part of it
+                            let new_entry = VirtualSpaceEntry {
+                                physical_start: Some(current_phy_start),
+                                virtual_start: current.virtual_start,
+                                size: new_size,
+                            };
+                            next_entry.size -= addition_size;
+                            next_entry.virtual_start += addition_size;
+                            cursor.insert_before(new_entry);
+                            return Some((true, current_phy_start + virt_offset));
+                        } else {
+                            // add `current` back
+                            cursor.insert_before(current);
+                            // next is already taken, we can't allocate
+                            // TODO: merge them together as one `allocated` chunk,
+                            //       would need the deallocator to be able to deallocate part as well
+                            return None;
+                        }
+                    }
+                }
+            }
+            cursor.move_next();
+        }
+        panic!("Could not find virtual space to ensure at least size")
+    }
+
+    fn allocate(&mut self, phy_start: u64, size: u64) -> u64 {
+        assert!(size > 0);
+        assert!(is_aligned(phy_start as _, PAGE_4K));
+        assert!(is_aligned(size as _, PAGE_4K));
+
+        let mut cursor = self.entries.cursor_front_mut();
+        // find largest fitting entry and allocate from it
+        while let Some(entry) = cursor.current() {
+            if entry.physical_start.is_none() && entry.size >= size {
+                // found it, split into two, and add to the list
+
+                // the new entry (after this)
+                let new_entry = VirtualSpaceEntry {
+                    physical_start: None,
+                    virtual_start: entry.virtual_start + size,
+                    size: entry.size - size,
+                };
+                // shrink this entry
+                entry.size = size;
+                entry.physical_start = Some(phy_start);
+                let virtual_address = entry.virtual_start;
+
+                // add the new entry
+                cursor.insert_after(new_entry);
+                return virtual_address;
+            }
+            cursor.move_next();
+        }
+        // if this is the first time, add a new entry and try again
+        if self.entries.is_empty() {
+            assert!(is_aligned(KERNEL_EXTRA_MEMORY_SIZE, PAGE_4K));
+            self.entries.push_back(VirtualSpaceEntry {
+                physical_start: None,
+                virtual_start: KERNEL_EXTRA_MEMORY_BASE as u64,
+                size: KERNEL_EXTRA_MEMORY_SIZE as u64,
+            });
+            self.allocate(phy_start, size)
+        } else {
+            panic!("Out of virtual space");
+        }
+    }
+
+    fn deallocate(&mut self, req_virtual_start: u64, req_size: u64) {
+        assert!(req_size > 0);
+        assert!(is_aligned(req_virtual_start as _, PAGE_4K));
+        assert!(is_aligned(req_size as _, PAGE_4K));
+
+        let mut cursor = self.entries.cursor_front_mut();
+        while let Some(entry) = cursor.current() {
+            // is inside?
+            if entry.virtual_start <= req_virtual_start
+                && entry.virtual_start + entry.size > req_virtual_start
+            {
+                // it must match the whole entry
+                if req_virtual_start != entry.virtual_start || req_size != entry.size {
+                    panic!("Requested to deallocate {:016X}..{:016X}, but its partially inside {:016X}..{:016X}, must match exactly", 
+                        req_virtual_start, req_virtual_start + req_size, entry.virtual_start, entry.virtual_start + entry.size);
+                }
+
+                // found it, deallocate it
+                assert!(entry.physical_start.is_some());
+                entry.physical_start = None;
+
+                // try to merge with after and before
+                // extract the current so we can play around with values easily
+                let mut current = cursor.remove_current().unwrap();
+
+                // merge with next
+                if let Some(next_entry) = cursor.current() {
+                    if next_entry.physical_start.is_none() {
+                        // merge with next
+                        current.size += next_entry.size;
+                        // here `cursor` is pointing to `next_entry`
+                        cursor.remove_current();
+                    }
+                }
+                // go the the previous entry (before current)
+                cursor.move_prev();
+                // merge with prev
+                if let Some(prev_entry) = cursor.current() {
+                    if prev_entry.physical_start.is_none() {
+                        // merge with prev
+                        prev_entry.size += current.size;
+                        // no need to remove the `current` since its already removed
+                    } else {
+                        // add `current` back
+                        cursor.insert_after(current);
+                    }
+                }
+                return;
+            }
+            cursor.move_next();
+        }
+        panic!("Could not find virtual space to deallocate");
+    }
+}

--- a/kernel/src/process/scheduler.rs
+++ b/kernel/src/process/scheduler.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use crate::{
     cpu::{self, idt::InterruptAllSavedState, interrupts},
-    memory_management::virtual_memory,
+    memory_management::virtual_memory_mapper,
     process::{syscalls, FxSave},
     sync::spin::mutex::Mutex,
 };
@@ -113,7 +113,7 @@ pub fn yield_current_if_any(all_state: &mut InterruptAllSavedState) {
         process.context = current_cpu.context.take().unwrap();
         process.state = ProcessState::Scheduled;
     });
-    virtual_memory::switch_to_kernel();
+    virtual_memory_mapper::switch_to_kernel();
     current_cpu.pop_cli();
 }
 


### PR DESCRIPTION
Fixes #7.

This is for objects and stuff that we know where they are physically,
and we want to use them, but we don't have a specific space we care
about virtually.

So this will allocate pages from the virtual space so that we can map
them together with the physical address that we know about.

We can do the following:
- `get_address`: try to find virtual mapping of a physical address if we
  have it, this will panic if you tell it you want some previous
  allocation but larger (check below).
- `ensure_size`: the address you give it is virtual, so it will find the
  mapping (must exist), and make sure the mapping is enough for your
  `size.
  If its not enough, it will check if it can allocate the space
  immediately after it, and if so, it will do that, otherwise it will
  panic.
- `allocate`: explicit allocation, this can be called with same physical
  address multiple times and it will result in multiple virtual
  mappings, should be used carefully as it can cause aliasing issues.
- `deallocate`: de-allocate virtual space.
  This can be probably used after for example reading all ACPI tables.
  At that stage, the memory won't be needed, but it is not done in this PR,
  as its quite annoying keeping track of ACPI tables and knowing when to free them
  since they overlap pages.
  But anyway, for other cases, such as memory mapped IO/buffers, it will stay
  throughout the lifespan of the OS.

There is several panics and we used explicit `ensure_size` instead of
making `get_address` do it, I think its better this way to reduce bugs.

Also with this `virtual space`, we got rid of the `DEVICE_MEMORY` region which was about 700MB, and instead
used `virtual space` whenever a device uses MMIO memory. Much easier, less space, and more dynamic.

Now we have around `1.8GB` of extra space, so we can easily add more heap or stack or anything in general.