### PR TITLE
Processes related syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,3 +19,10 @@ version = "0.1.0"
 dependencies = [
  "common",
 ]
+
+[[package]]
+name = "shell"
+version = "0.1.0"
+dependencies = [
+ "common",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ default-members = ["kernel"]
 members = [
     "common",
     "kernel",
-    "userspace/init",
+    "userspace/init", "userspace/shell",
 ]

--- a/common/src/syscalls.rs
+++ b/common/src/syscalls.rs
@@ -6,13 +6,14 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 4;
+pub const NUM_SYSCALLS: usize = 5;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
     pub const SYS_WRITE: u64 = 1;
     pub const SYS_READ: u64 = 2;
     pub const SYS_EXIT: u64 = 3;
+    pub const SYS_SPAWN: u64 = 4;
 }
 pub use numbers::*;
 
@@ -208,6 +209,8 @@ pub enum SyscallError {
     InvalidFileIndex = 3,
     CouldNotWriteToFile = 4,
     CouldNotReadFromFile = 5,
+    CouldNotLoadElf = 6,
+    CouldNotAllocateProcess = 7,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -287,6 +290,8 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::InvalidFileIndex => 3 << 56,
                 SyscallError::CouldNotWriteToFile => 4 << 56,
                 SyscallError::CouldNotReadFromFile => 5 << 56,
+                SyscallError::CouldNotLoadElf => 6 << 56,
+                SyscallError::CouldNotAllocateProcess => 7 << 56,
             };
 
             err_upper | (1 << 63)
@@ -329,6 +334,8 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             3 => SyscallError::InvalidFileIndex,
             4 => SyscallError::CouldNotWriteToFile,
             5 => SyscallError::CouldNotReadFromFile,
+            6 => SyscallError::CouldNotLoadElf,
+            7 => SyscallError::CouldNotAllocateProcess,
             _ => invalid_error_code(()),
         };
         SyscallResult::Err(err)

--- a/common/src/syscalls.rs
+++ b/common/src/syscalls.rs
@@ -6,7 +6,7 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 5;
+pub const NUM_SYSCALLS: usize = 6;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
@@ -14,6 +14,7 @@ mod numbers {
     pub const SYS_READ: u64 = 2;
     pub const SYS_EXIT: u64 = 3;
     pub const SYS_SPAWN: u64 = 4;
+    pub const SYS_INC_HEAP: u64 = 5;
 }
 pub use numbers::*;
 
@@ -185,6 +186,7 @@ pub enum SyscallArgError {
     GeneralInvalid = 1,
     InvalidUserPointer = 2,
     NotValidUtf8 = 3,
+    InvalidHeapIncrement = 4,
 }
 
 impl SyscallArgError {
@@ -194,6 +196,7 @@ impl SyscallArgError {
             1 => Ok(Some(SyscallArgError::GeneralInvalid)),
             2 => Ok(Some(SyscallArgError::InvalidUserPointer)),
             3 => Ok(Some(SyscallArgError::NotValidUtf8)),
+            4 => Ok(Some(SyscallArgError::InvalidHeapIncrement)),
             _ => Err(()),
         }
     }
@@ -211,6 +214,7 @@ pub enum SyscallError {
     CouldNotReadFromFile = 5,
     CouldNotLoadElf = 6,
     CouldNotAllocateProcess = 7,
+    HeapRangesExceeded = 8,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -292,6 +296,7 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::CouldNotReadFromFile => 5 << 56,
                 SyscallError::CouldNotLoadElf => 6 << 56,
                 SyscallError::CouldNotAllocateProcess => 7 << 56,
+                SyscallError::HeapRangesExceeded => 8 << 56,
             };
 
             err_upper | (1 << 63)
@@ -336,6 +341,7 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             5 => SyscallError::CouldNotReadFromFile,
             6 => SyscallError::CouldNotLoadElf,
             7 => SyscallError::CouldNotAllocateProcess,
+            8 => SyscallError::HeapRangesExceeded,
             _ => invalid_error_code(()),
         };
         SyscallResult::Err(err)

--- a/common/src/syscalls.rs
+++ b/common/src/syscalls.rs
@@ -6,12 +6,13 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 3;
+pub const NUM_SYSCALLS: usize = 4;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
     pub const SYS_WRITE: u64 = 1;
     pub const SYS_READ: u64 = 2;
+    pub const SYS_EXIT: u64 = 3;
 }
 pub use numbers::*;
 
@@ -19,10 +20,10 @@ pub use numbers::*;
 /// RCX, RDX, RSI, RDI, R8, R9, R10 (7 arguments max)
 #[macro_export]
 macro_rules! call_syscall {
-    ($syscall_num:expr) => {
+    ($syscall_num:expr $(,)?) => {
         call_syscall!(@step $syscall_num; { }; { })
     };
-    ($syscall_num:expr, $($args:expr),*) => {
+    ($syscall_num:expr, $($args:expr),* $(,)?) => {
         call_syscall!(@step $syscall_num; { }; {$($args),*})
     };
     (@step $syscall_num: expr; {$($generated:tt)*}; {}) => {

--- a/common/src/syscalls/types_conversions.rs
+++ b/common/src/syscalls/types_conversions.rs
@@ -1,43 +1,28 @@
 use super::{FromSyscallArgU64, SyscallArgError};
 
-impl FromSyscallArgU64 for u64 {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value)
-    }
+macro_rules! impl_convert_for_args {
+    ($($typ:ty),*) => {
+        $(
+            impl FromSyscallArgU64 for $typ {
+                fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
+                    Ok(value as Self)
+                }
+            }
+        )*
+    };
 }
 
-impl FromSyscallArgU64 for usize {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value as usize)
-    }
-}
-
-impl FromSyscallArgU64 for u32 {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value as u32)
-    }
-}
-
-impl FromSyscallArgU64 for u16 {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value as u16)
-    }
-}
-
-impl FromSyscallArgU64 for u8 {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value as u8)
-    }
-}
-
-impl FromSyscallArgU64 for *const u8 {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value as *const u8)
-    }
-}
-
-impl FromSyscallArgU64 for *mut u8 {
-    fn from_syscall_arg_u64(value: u64) -> Result<Self, SyscallArgError> {
-        Ok(value as *mut u8)
-    }
-}
+impl_convert_for_args![
+    i64,
+    i32,
+    i16,
+    i8,
+    isize,
+    u64,
+    u32,
+    u16,
+    u8,
+    usize,
+    *const u8,
+    *mut u8
+];

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -27,6 +27,7 @@ mod sync;
 
 use core::hint;
 
+use alloc::vec::Vec;
 use common::{FD_STDERR, FD_STDIN, FD_STDOUT};
 use cpu::{
     gdt,
@@ -81,7 +82,7 @@ fn finish_boot() {
 fn load_init_process() {
     let mut init_file = fs::open("/init").expect("Could not find `init` file");
     let elf = Elf::load(&mut init_file).expect("Could not load init file");
-    let mut process = Process::allocate_process(0, &elf, &mut init_file)
+    let mut process = Process::allocate_process(0, &elf, &mut init_file, Vec::new())
         .expect("Could not allocate process for `init`");
     assert!(process.id() == 0, "Must be the first process");
 

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -29,7 +29,7 @@ pub const KERNEL_HEAP_BASE: usize = KERNEL_END;
 pub const KERNEL_HEAP_SIZE: usize = 0x100_0000; // 16MB
 
 // The size of the stack for interrupt handlers
-pub const INTR_STACK_SIZE: usize = PAGE_4K * 4;
+pub const INTR_STACK_SIZE: usize = PAGE_4K * 8;
 pub const INTR_STACK_EMPTY_SIZE: usize = PAGE_4K;
 pub const INTR_STACK_ENTRY_SIZE: usize = INTR_STACK_SIZE + INTR_STACK_EMPTY_SIZE;
 pub const INTR_STACK_BASE: usize = KERNEL_HEAP_BASE + KERNEL_HEAP_SIZE;

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -45,6 +45,10 @@ pub const KERNEL_EXTRA_MEMORY_BASE: usize = INTR_STACK_BASE + INTR_STACK_TOTAL_S
 pub const KERNEL_LAST_POSSIBLE_ADDR: usize = 0xFFFF_FFFF_FFFF_F000;
 pub const KERNEL_EXTRA_MEMORY_SIZE: usize = KERNEL_LAST_POSSIBLE_ADDR - KERNEL_EXTRA_MEMORY_BASE;
 
+#[allow(dead_code)]
+pub const KB: usize = 0x400;
+pub const MB: usize = 0x100_000;
+pub const GB: usize = 0x400_00000;
 pub const PAGE_4K: usize = 0x1000;
 pub const PAGE_2M: usize = 0x20_0000;
 

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -155,7 +155,7 @@ pub fn unmap_kernel(entry: &VirtualMemoryMapEntry, is_allocated: bool) {
     assert!(entry.virtual_address >= KERNEL_BASE as u64);
     KERNEL_VIRTUAL_MEMORY_MANAGER
         .lock()
-        .unmap_impl(entry, is_allocated);
+        .unmap(entry, is_allocated);
 }
 
 #[allow(dead_code)]
@@ -269,7 +269,7 @@ impl VirtualMemoryMapper {
         }
 
         // unmap stack guard
-        s.unmap_impl(
+        s.unmap(
             &VirtualMemoryMapEntry {
                 virtual_address: stack_guard_page_ptr() as u64,
                 physical_address: None,
@@ -469,7 +469,7 @@ impl VirtualMemoryMapper {
     }
 
     /// Removes mapping of a virtual entry, it will free it from physical memory if it was allocated
-    fn unmap_impl(&mut self, entry: &VirtualMemoryMapEntry, is_allocated: bool) {
+    pub fn unmap(&mut self, entry: &VirtualMemoryMapEntry, is_allocated: bool) {
         let VirtualMemoryMapEntry {
             mut virtual_address,
             physical_address,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -90,6 +90,7 @@ pub struct ProcessContext {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessState {
     Running,
+    Yielded, // Not used now, but should be scheduled next
     Scheduled,
     Sleeping,
     Exited,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -90,7 +90,7 @@ pub enum ProcessState {
     Running,
     Scheduled,
     Sleeping,
-    Stopped,
+    Exited,
 }
 
 // TODO: implement threads, for now each process acts as a thread also
@@ -109,6 +109,8 @@ pub struct Process {
     stack_size: usize,
 
     state: ProcessState,
+    // split from the state, so that we can keep it as a simple enum
+    exit_code: u64,
 }
 
 impl Process {
@@ -153,10 +155,11 @@ impl Process {
             stack_ptr_end: stack_end - 8, // 8 bytes for padding
             stack_size,
             state: ProcessState::Scheduled,
+            exit_code: 0,
         })
     }
 
-    pub fn switch_to_this(&mut self) {
+    pub fn switch_to_this_vm(&mut self) {
         self.vm.switch_to_this();
     }
 
@@ -196,6 +199,11 @@ impl Process {
 
     pub fn get_file(&mut self, fd: usize) -> Option<&mut fs::File> {
         self.open_files.get_mut(&fd)
+    }
+
+    pub fn exit(&mut self, exit_code: u64) {
+        self.state = ProcessState::Exited;
+        self.exit_code = exit_code;
     }
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -11,7 +11,9 @@ use crate::{
     fs,
     memory_management::{
         memory_layout::{KERNEL_BASE, PAGE_4K},
-        virtual_memory_mapper::{self, VirtualMemoryMapEntry, VirtualMemoryMapper},
+        virtual_memory_mapper::{
+            self, VirtualMemoryMapEntry, VirtualMemoryMapper, MAX_USER_VIRTUAL_ADDRESS,
+        },
     },
 };
 
@@ -121,7 +123,7 @@ impl Process {
     ) -> Result<Self, ProcessError> {
         let id = PROCESS_ID_ALLOCATOR.allocate();
         let mut vm = virtual_memory_mapper::clone_kernel_vm_as_user();
-        let stack_end = KERNEL_BASE - PAGE_4K;
+        let stack_end = MAX_USER_VIRTUAL_ADDRESS - PAGE_4K;
         let stack_size = INITIAL_STACK_SIZE_PAGES * PAGE_4K;
         let stack_start = stack_end - stack_size;
         vm.map(&VirtualMemoryMapEntry {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -3,7 +3,7 @@ mod syscalls;
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use alloc::collections::BTreeMap;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
 use crate::{
     cpu::{self, gdt},
@@ -107,6 +107,8 @@ pub struct Process {
     open_files: BTreeMap<usize, fs::File>,
     file_index_allocator: GoingUpAllocator,
 
+    argv: Vec<String>,
+
     stack_ptr_end: usize,
     stack_size: usize,
 
@@ -120,6 +122,7 @@ impl Process {
         parent_id: u64,
         elf: &elf::Elf,
         file: &mut fs::File,
+        argv: Vec<String>,
     ) -> Result<Self, ProcessError> {
         let id = PROCESS_ID_ALLOCATOR.allocate();
         let mut vm = virtual_memory_mapper::clone_kernel_vm_as_user();
@@ -154,6 +157,7 @@ impl Process {
             parent_id,
             open_files: BTreeMap::new(),
             file_index_allocator: GoingUpAllocator::new(),
+            argv,
             stack_ptr_end: stack_end - 8, // 8 bytes for padding
             stack_size,
             state: ProcessState::Scheduled,

--- a/kernel/src/process/scheduler.rs
+++ b/kernel/src/process/scheduler.rs
@@ -60,7 +60,7 @@ pub fn schedule() -> ! {
         // no context holding, i.e. free to take a new process
         for process in scheduler.processes.iter_mut() {
             match process.state {
-                ProcessState::Scheduled => {
+                ProcessState::Scheduled if current_cpu.context.is_none() => {
                     // found a process to run
                     current_cpu.push_cli();
                     process.state = ProcessState::Running;

--- a/kernel/src/process/scheduler.rs
+++ b/kernel/src/process/scheduler.rs
@@ -59,23 +59,37 @@ pub fn schedule() -> ! {
         let mut scheduler = SCHEDULER.lock();
         // no context holding, i.e. free to take a new process
         for process in scheduler.processes.iter_mut() {
-            if process.state == ProcessState::Scheduled {
-                current_cpu.push_cli();
-                process.state = ProcessState::Running;
-                process.switch_to_this();
-                current_cpu.process_id = process.id;
-                current_cpu.context = Some(process.context);
+            match process.state {
+                ProcessState::Scheduled => {
+                    // found a process to run
+                    current_cpu.push_cli();
+                    process.state = ProcessState::Running;
+                    process.switch_to_this_vm();
+                    current_cpu.process_id = process.id;
+                    current_cpu.context = Some(process.context);
 
-                current_cpu.pop_cli();
+                    current_cpu.pop_cli();
+                }
+                ProcessState::Exited => {
+                    // keep the process for one time, it will be deleted later.
+                    // this is if we want to do extra stuff later
+                }
+                _ => {}
             }
         }
+        scheduler
+            .processes
+            .retain(|p| p.state != ProcessState::Exited);
         drop(scheduler);
 
         if current_cpu.context.is_some() {
             // call scheduler_interrupt_handler
             // we are using interrupts to switch context since it allows us to save the registers of exit, which is
             // very convenient
-            unsafe { core::arch::asm!("int 0xff") }
+            // The `sys_exit` syscall changes the context from user to kernel,
+            // and because of how we implemented syscalls, the result will be in `rax`, so we tell
+            // the compiler to ignore `rax` as it may be clobbered after this call
+            unsafe { core::arch::asm!("int 0xff", out("rax") _) }
         } else {
             // no process to run, just wait for interrupts
             unsafe { cpu::halt() };
@@ -96,6 +110,38 @@ where
         .find(|p| p.id == current_cpu.process_id)
         .expect("current process not found");
     f(process)
+}
+
+/// Exit the current process, and move the `all_state` to the scheduler.
+/// The caller of this function (i.e. interrupt) will use the `all_state` to go back to the scheduler.
+/// This function will remove the context from the CPU, and thus the value in `all_state` will be dropped.
+pub fn exit_current_process(exit_code: u64, all_state: &mut InterruptAllSavedState) {
+    let current_cpu = cpu::cpu();
+    let mut scheduler = SCHEDULER.lock();
+
+    // TODO: find a better way to store processes or store process index/id.
+    let process = scheduler
+        .processes
+        .iter_mut()
+        .find(|p| p.id == current_cpu.process_id)
+        .expect("current process not found");
+
+    assert!(process.state == ProcessState::Running);
+    assert!(current_cpu.context.is_some());
+
+    // exit process and go back to scheduler (through the syscall handler)
+    current_cpu.push_cli();
+    process.exit(exit_code);
+    // TODO: notify listeners for this process
+    println!("Process {} exited with code {}", process.id, exit_code);
+
+    // this will have the state of the cpu in the scheduler
+    swap_context(current_cpu.context.as_mut().unwrap(), all_state);
+    // drop the cpu context, i.e. drop the current process context
+    // the virtual memory will be cleared once we drop the process
+    current_cpu.context = None;
+    virtual_memory_mapper::switch_to_kernel();
+    current_cpu.pop_cli();
 }
 
 pub fn yield_current_if_any(all_state: &mut InterruptAllSavedState) {

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -1,15 +1,21 @@
 use core::ffi::CStr;
 
+use alloc::{string::String, vec::Vec};
 use common::{
     sys_arg,
     syscalls::{
         syscall_arg_to_u64, syscall_handler_wrapper, SyscallArgError, SyscallError, SyscallResult,
         NUM_SYSCALLS,
     },
-    to_arg_err, verify_args,
+    to_arg_err, verify_args, FD_STDERR, FD_STDIN, FD_STDOUT,
 };
 
-use crate::{cpu::idt::InterruptAllSavedState, fs};
+use crate::{
+    cpu::idt::InterruptAllSavedState,
+    executable::elf::Elf,
+    fs,
+    process::{scheduler, Process},
+};
 
 use super::scheduler::{exit_current_process, with_current_process};
 
@@ -20,6 +26,7 @@ const SYSCALLS: [Syscall; NUM_SYSCALLS] = [
     sys_write, // common::syscalls::SYS_WRITE
     sys_read,  // common::syscalls::SYS_READ
     sys_exit,  // common::syscalls::SYS_EXIT
+    sys_spawn, // common::syscalls::SYS_SPAWN
 ];
 
 #[inline]
@@ -38,6 +45,7 @@ fn check_ptr(arg: *const u8, len: u64) -> Result<(), SyscallArgError> {
     Ok(())
 }
 
+// expects null terminated string
 fn sys_arg_to_str<'a>(arg: *const u8) -> Result<&'a str, SyscallArgError> {
     check_ptr(arg, 1)?;
 
@@ -58,6 +66,29 @@ fn sys_arg_to_mut_byte_slice<'a>(buf: *mut u8, size: u64) -> Result<&'a mut [u8]
 
     let slice = unsafe { core::slice::from_raw_parts_mut(buf as _, size as _) };
     Ok(slice)
+}
+
+/// Allocates space for the strings and copies them
+fn sys_arg_to_str_array(array_ptr: *const u8) -> Result<Vec<String>, SyscallArgError> {
+    check_ptr(array_ptr, 8)?;
+    let array_ptr = array_ptr as *const *const u8;
+
+    let mut array = Vec::new();
+    let mut i = 0;
+    loop {
+        let ptr = unsafe { *array_ptr.offset(i) };
+        if ptr.is_null() {
+            break;
+        }
+        let str = sys_arg_to_str(ptr)?;
+        if str.is_empty() {
+            break;
+        }
+        array.push(String::from(str));
+        i += 1;
+    }
+
+    Ok(array)
 }
 
 fn sys_open(all_state: &mut InterruptAllSavedState) -> SyscallResult {
@@ -117,6 +148,34 @@ fn sys_exit(all_state: &mut InterruptAllSavedState) -> SyscallResult {
     // modify the all_state to go back to the kernel, the current all_state will be dropped
     exit_current_process(exit_code, all_state);
     SyscallResult::Ok(exit_code)
+}
+
+fn sys_spawn(all_state: &mut InterruptAllSavedState) -> SyscallResult {
+    let (path, argv, ..) = verify_args! {
+        sys_arg!(0, all_state.rest => sys_arg_to_str(*const u8)),
+        sys_arg!(1, all_state.rest => u64),   // array of pointers
+    };
+    let argv = argv as *const u8;
+
+    let argv = sys_arg_to_str_array(argv).map_err(|err| to_arg_err!(1, err))?;
+    let mut file = fs::open(path).map_err(|_| SyscallError::CouldNotOpenFile)?;
+    let elf = Elf::load(&mut file).map_err(|_| SyscallError::CouldNotLoadElf)?;
+    let current_pid = with_current_process(|process| process.id);
+    let mut process = Process::allocate_process(current_pid, &elf, &mut file, argv)
+        .map_err(|_| SyscallError::CouldNotAllocateProcess)?;
+
+    // TODO: setup inheritance for process files
+
+    // add the console manually for now,
+    let console = fs::open("/devices/console").expect("Could not find `/devices/console`");
+    process.attach_file_to_fd(FD_STDIN, console.clone());
+    process.attach_file_to_fd(FD_STDOUT, console.clone());
+    process.attach_file_to_fd(FD_STDERR, console);
+
+    let new_pid = process.id();
+    scheduler::push_process(process);
+
+    SyscallResult::Ok(new_pid)
 }
 
 pub fn handle_syscall(all_state: &mut InterruptAllSavedState) {

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -5,7 +5,7 @@ use core::ffi::{c_char, CStr};
 
 use common::{
     call_syscall,
-    syscalls::{SYS_EXIT, SYS_SPAWN, SYS_WRITE},
+    syscalls::{SYS_EXIT, SYS_INC_HEAP, SYS_SPAWN, SYS_WRITE},
     FD_STDOUT,
 };
 
@@ -43,14 +43,37 @@ fn spawn(path: &CStr, argv: &[*const c_char]) -> u64 {
     }
 }
 
-fn convert_to_string(mut number: i32, buffer: &mut [u8]) -> usize {
+fn allocate_heap(size: usize) -> *mut u8 {
+    unsafe {
+        call_syscall!(
+            SYS_INC_HEAP,
+            size as u64, // increment
+        )
+        .unwrap() as *mut u8
+    }
+}
+
+fn get_heap_end_ptr() -> *mut u8 {
+    unsafe {
+        call_syscall!(
+            SYS_INC_HEAP,
+            0, // increment
+        )
+        .unwrap() as *mut u8
+    }
+}
+
+fn convert_to_string(mut number: i64, radix: u8, buffer: &mut [u8]) -> usize {
+    assert!((2..=16).contains(&radix));
+    const RADIX_CHARS: &[u8] = b"0123456789ABCDEF";
+
     let mut i = 0;
     if number < 0 {
         buffer[i] = b'-';
         i += 1;
         number = -number;
     }
-    let mut n = number as u32;
+    let mut n = number as u64;
     if n == 0 {
         buffer[i] = b'0';
         i += 1;
@@ -58,13 +81,13 @@ fn convert_to_string(mut number: i32, buffer: &mut [u8]) -> usize {
         let mut len = 0;
         while n > 0 {
             len += 1;
-            n /= 10;
+            n /= radix as u64;
         }
-        let mut n = number as u32;
+        let mut n = number as u64;
         while n > 0 {
             i += 1;
-            buffer[len - i] = (n % 10) as u8 + b'0';
-            n /= 10;
+            buffer[len - i] = RADIX_CHARS[(n % radix as u64) as usize];
+            n /= radix as u64;
         }
     }
     i
@@ -84,14 +107,41 @@ pub extern "C" fn _start() -> ! {
     let msg = c"[init] spawned shell with pid ";
     let msg_len = msg.to_bytes().len();
     buf[..msg_len].copy_from_slice(msg.to_bytes());
-    let len = convert_to_string(shell_pid as i32, &mut buf[msg_len..]);
+    let len = convert_to_string(shell_pid as _, 10, &mut buf[msg_len..]);
     buf[msg_len + len] = b'\n';
     write_to_stdout(unsafe { CStr::from_bytes_with_nul_unchecked(&buf) });
+
+    let heap_size = 0x1000;
+    let heap_start = allocate_heap(heap_size);
+    assert!(get_heap_end_ptr() == unsafe { heap_start.add(heap_size) });
+
+    // use the data in the heap to print the heap start ptr
+    let arr_at_heap = unsafe { core::slice::from_raw_parts_mut(heap_start, heap_size) };
+    // zero out
+    arr_at_heap.fill(0);
+    let msg = c"[init] Got new heap at: 0x";
+    arr_at_heap[..msg.to_bytes().len()].copy_from_slice(msg.to_bytes());
+    // put the heap start ptr as integer
+    let len = convert_to_string(
+        heap_start as _,
+        16,
+        &mut arr_at_heap[msg.to_bytes().len()..],
+    );
+    arr_at_heap[msg.to_bytes().len() + len] = b'\n';
+    // print
+    write_to_stdout(unsafe { CStr::from_bytes_with_nul_unchecked(arr_at_heap) });
     exit(111);
 }
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
-    write_to_stdout(c"[init] panicked!\n");
+    let mut buf = [0u8; 100];
+    let msg = c"[init] panicked!, line: ";
+    buf[..msg.to_bytes().len()].copy_from_slice(msg.to_bytes());
+    let line = _info.location().unwrap().line();
+    let len = convert_to_string(line as _, 10, &mut buf[msg.to_bytes().len()..]);
+    buf[msg.to_bytes().len() + len] = b'\n';
+    write_to_stdout(unsafe { CStr::from_bytes_with_nul_unchecked(&buf) });
+    // write_to_stdout(c"[init] panicked!\n");
     exit(0xFF);
 }

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -5,7 +5,7 @@ use core::{ffi::CStr, hint};
 
 use common::{
     call_syscall,
-    syscalls::{SYS_OPEN, SYS_READ, SYS_WRITE},
+    syscalls::{SYS_EXIT, SYS_OPEN, SYS_READ, SYS_WRITE},
     FD_STDOUT,
 };
 
@@ -45,6 +45,17 @@ fn read_file(fd: u64, buf: &mut [u8]) -> u64 {
     }
 }
 
+fn exit(code: u64) -> ! {
+    unsafe {
+        call_syscall!(
+            SYS_EXIT,
+            code, // code
+        )
+        .unwrap();
+    }
+    unreachable!("exit syscall should not return")
+}
+
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     // we are in `init` now
@@ -59,9 +70,7 @@ pub extern "C" fn _start() -> ! {
     buf[read as usize] = 0; // null terminate
     write_to_stdout(CStr::from_bytes_until_nul(&buf[..read as usize + 1]).unwrap());
 
-    loop {
-        hint::spin_loop();
-    }
+    exit(123);
 }
 
 #[panic_handler]

--- a/userspace/shell/Cargo.toml
+++ b/userspace/shell/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "shell"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+common = { path = "../../common" }

--- a/userspace/shell/src/main.rs
+++ b/userspace/shell/src/main.rs
@@ -1,0 +1,80 @@
+#![no_std]
+#![no_main]
+
+use core::ffi::CStr;
+
+use common::{
+    call_syscall,
+    syscalls::{SYS_EXIT, SYS_OPEN, SYS_READ, SYS_WRITE},
+    FD_STDOUT,
+};
+
+fn write_to_stdout(s: &CStr) {
+    unsafe {
+        call_syscall!(
+            SYS_WRITE,
+            FD_STDOUT,                 // fd
+            s.as_ptr() as u64,         // buf
+            s.to_bytes().len() as u64  // size
+        )
+        .unwrap();
+    }
+}
+
+fn open_file(path: &CStr) -> u64 {
+    unsafe {
+        call_syscall!(
+            SYS_OPEN,
+            path.as_ptr() as u64, // path
+            0,                    // flags
+            0                     // mode
+        )
+        .unwrap()
+    }
+}
+
+fn read_file(fd: u64, buf: &mut [u8]) -> u64 {
+    unsafe {
+        call_syscall!(
+            SYS_READ,
+            fd,                      // fd
+            buf.as_mut_ptr() as u64, // buf
+            buf.len() as u64         // size
+        )
+        .unwrap()
+    }
+}
+
+fn exit(code: u64) -> ! {
+    unsafe {
+        call_syscall!(
+            SYS_EXIT,
+            code, // code
+        )
+        .unwrap();
+    }
+    unreachable!("exit syscall should not return")
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    // we are in `init` now
+    // create some delay
+    write_to_stdout(c"[shell] Hello!\n\n");
+
+    // open `/message.txt` and print the result
+    let fd = open_file(c"/message.txt");
+    write_to_stdout(c"[shell] content of `/message.txt`:\n");
+    let mut buf = [0u8; 1024];
+    let read = read_file(fd, &mut buf);
+    buf[read as usize] = 0; // null terminate
+    write_to_stdout(CStr::from_bytes_until_nul(&buf[..read as usize + 1]).unwrap());
+
+    exit(222);
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    write_to_stdout(c"[shell] panicked!\n");
+    exit(0xFF);
+}


### PR DESCRIPTION
Fixes #11 .

Added:
- `exit`
- `spawn`: this doesn't fork or anything, just basic loading of elf file into user memory and adding it to the scheduler.
- `inc_heap`: something like `sbrk` control the end of the heap, data break. The program starts with `0` allocated heap, and this must be used to allocate new heap