### PR TITLE
Process heap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,10 @@
 version = 3
 
 [[package]]
+name = "increasing_heap_allocator"
+version = "0.1.0"
+
+[[package]]
 name = "init"
 version = "0.1.0"
 dependencies = [
@@ -13,6 +17,7 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "increasing_heap_allocator",
  "kernel_user_link",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ name = "init"
 version = "0.1.0"
 dependencies = [
  "kernel_user_link",
+ "user_std",
 ]
 
 [[package]]
@@ -29,5 +30,14 @@ version = "0.1.0"
 name = "shell"
 version = "0.1.0"
 dependencies = [
+ "kernel_user_link",
+ "user_std",
+]
+
+[[package]]
+name = "user_std"
+version = "0.1.0"
+dependencies = [
+ "increasing_heap_allocator",
  "kernel_user_link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ default-members = ["kernel"]
 members = [
     "libraries/kernel_user_link",
     "kernel",
-    "userspace/init", "userspace/shell",
+    "userspace/init", "userspace/shell", "libraries/increasing_heap_allocator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ default-members = ["kernel"]
 members = [
     "libraries/kernel_user_link",
     "kernel",
-    "userspace/init", "userspace/shell", "libraries/increasing_heap_allocator",
+    "userspace/init", "userspace/shell", "libraries/increasing_heap_allocator", "libraries/user_std",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,7 +27,7 @@ args = ["-r", "${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}", "${FILESYSTEM_PATH}/${CAR
 [tasks.filesystem]
 workspace = false
 # empty array means all members (not sure why need to be explicit)
-env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS=[], CARGO_MAKE_WORKSPACE_SKIP_MEMBERS=["kernel", "libraries/kernel_user_link"] }
+env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS=[], CARGO_MAKE_WORKSPACE_SKIP_MEMBERS=["kernel", "libraries/*"] }
 run_task = { name = "copy_to_fs", fork = true }
 
 # kernel tasks

--- a/kernel/src/memory_management/kernel_heap_allocator.rs
+++ b/kernel/src/memory_management/kernel_heap_allocator.rs
@@ -1,189 +1,36 @@
-use core::{alloc::GlobalAlloc, mem};
+use core::alloc::{GlobalAlloc, Layout};
+
+use increasing_heap_allocator::{HeapAllocator, HeapStats, PageAllocatorProvider};
 
 use crate::{
     memory_management::{
-        memory_layout::{is_aligned, KERNEL_HEAP_SIZE},
+        memory_layout::KERNEL_HEAP_SIZE,
         virtual_memory_mapper::{self, flags, VirtualMemoryMapEntry},
     },
-    sync::spin::mutex::Mutex,
+    sync::{once::OnceLock, spin::mutex::Mutex},
 };
 
-use super::memory_layout::{align_up, KERNEL_HEAP_BASE, PAGE_4K};
-
-const KERNEL_HEAP_MAGIC: u32 = 0xF0B0CAFE;
+use super::memory_layout::{KERNEL_HEAP_BASE, PAGE_4K};
 
 #[global_allocator]
 pub static ALLOCATOR: LockedKernelHeapAllocator = LockedKernelHeapAllocator::empty();
 
-#[repr(C, align(16))]
-struct AllocatedHeapBlockInfo {
-    magic: u32,
-    size: usize,
-    pre_padding: usize,
-}
-
-const KERNEL_HEAP_BLOCK_INFO_SIZE: usize = mem::size_of::<AllocatedHeapBlockInfo>();
-
-#[derive(Debug)]
-struct HeapFreeBlock {
-    prev: *mut HeapFreeBlock,
-    next: *mut HeapFreeBlock,
-    // including this header
-    size: usize,
-}
-
-struct KernelHeapAllocator {
+struct PageAllocator {
     heap_start: usize,
     mapped_pages: usize,
-    free_list_addr: *mut HeapFreeBlock,
-    free_size: usize,
-    used_size: usize,
 }
 
-unsafe impl Send for KernelHeapAllocator {}
-
-impl KernelHeapAllocator {
-    const fn empty() -> Self {
+impl PageAllocator {
+    fn new() -> Self {
         Self {
             heap_start: KERNEL_HEAP_BASE,
             mapped_pages: 0,
-            free_list_addr: core::ptr::null_mut(),
-            free_size: 0,
-            used_size: 0,
         }
     }
+}
 
-    fn is_free_blocks_in_cycle(&self) -> bool {
-        // use floyd algorithm to detect if we are in cycle
-        let mut slow = self.free_list_addr;
-        let mut fast = self.free_list_addr;
-
-        // advance fast first
-        if fast.is_null() {
-            return false;
-        } else {
-            fast = unsafe { (*fast).next };
-        }
-
-        while fast != slow {
-            if fast.is_null() {
-                return false;
-            } else {
-                fast = unsafe { (*fast).next };
-            }
-            if fast.is_null() {
-                return false;
-            } else {
-                fast = unsafe { (*fast).next };
-            }
-
-            if slow.is_null() {
-                return false;
-            } else {
-                slow = unsafe { (*slow).next };
-            }
-        }
-
-        true
-    }
-
-    fn check_free_blocks(&self) -> bool {
-        let mut forward_count = 0;
-        let mut last: *mut HeapFreeBlock = core::ptr::null_mut();
-        for block in self.iter_free_blocks() {
-            forward_count += 1;
-            last = block as _;
-        }
-
-        let mut backward_count = 0;
-        if !last.is_null() {
-            // go back to the first block
-            while !last.is_null() {
-                backward_count += 1;
-                last = unsafe { (*last).prev };
-            }
-        }
-
-        forward_count != backward_count
-    }
-
-    fn check_issues(&self) -> bool {
-        self.is_free_blocks_in_cycle() || self.check_free_blocks()
-    }
-
-    fn debug_free_blocks(&self) {
-        println!();
-        let mut last: *mut HeapFreeBlock = core::ptr::null_mut();
-        for block in self.iter_free_blocks() {
-            let block_start = block as *mut _ as usize;
-            println!(
-                "Free block at {:p}..{:p}",
-                block_start as *const u8,
-                (block_start + block.size) as *const u8
-            );
-            last = block as _;
-        }
-
-        println!("--- Backwards ---");
-
-        if !last.is_null() {
-            // go back to the first block
-            while !last.is_null() {
-                let block_start = last as *mut _ as usize;
-                println!(
-                    "Free block at {:p}..{:p}",
-                    block_start as *const u8,
-                    (block_start + unsafe { (*last).size }) as *const u8
-                );
-
-                last = unsafe { (*last).prev };
-            }
-        }
-    }
-
-    fn get_free_block(&mut self, size: usize) -> *mut HeapFreeBlock {
-        if self.mapped_pages == 0 {
-            let size = align_up(size, PAGE_4K);
-            self.allocate_more_pages(size / PAGE_4K);
-            // call recursively
-            return self.get_free_block(size);
-        }
-        // find best block
-        let mut best_block: *mut HeapFreeBlock = core::ptr::null_mut();
-        for block in self.iter_free_blocks() {
-            if block.size >= size
-                && (best_block.is_null() || block.size < unsafe { (*best_block).size })
-            {
-                best_block = block as _;
-            }
-        }
-
-        if best_block.is_null() {
-            // no block found, allocate more pages
-            let size = align_up(size, PAGE_4K);
-            self.allocate_more_pages(size / PAGE_4K);
-            // call recursively
-            return self.get_free_block(size);
-        }
-
-        best_block
-    }
-
-    fn iter_free_blocks(&self) -> impl Iterator<Item = &mut HeapFreeBlock> {
-        let mut current_block = self.free_list_addr;
-        core::iter::from_fn(move || {
-            if current_block.is_null() {
-                None
-            } else {
-                let block = current_block;
-                current_block = unsafe { (*current_block).next };
-                Some(unsafe { &mut *block })
-            }
-        })
-    }
-
-    /// Allocates more pages and add them to the free list
-    fn allocate_more_pages(&mut self, pages: usize) {
+impl PageAllocatorProvider<PAGE_4K> for PageAllocator {
+    fn allocate_pages(&mut self, pages: usize) -> Option<*mut u8> {
         eprintln!("Allocating {} pages", pages);
         assert!(pages > 0);
 
@@ -191,7 +38,9 @@ impl KernelHeapAllocator {
         let current_heap_base = last_heap_base;
 
         // do not exceed the heap size
-        assert!((self.mapped_pages + pages) * PAGE_4K <= KERNEL_HEAP_SIZE);
+        if (self.mapped_pages + pages) * PAGE_4K > KERNEL_HEAP_SIZE {
+            return None;
+        }
 
         virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
             virtual_address: current_heap_base as u64,
@@ -202,353 +51,47 @@ impl KernelHeapAllocator {
 
         self.mapped_pages += pages;
 
-        // add to the free list (fast path)
-        if self.free_list_addr.is_null() {
-            // no free list for now, add this as the very first free entry
-            let free_block = last_heap_base as *mut HeapFreeBlock;
-
-            unsafe {
-                (*free_block).prev = core::ptr::null_mut();
-                (*free_block).next = core::ptr::null_mut();
-                (*free_block).size = pages * PAGE_4K;
-            }
-
-            self.free_list_addr = free_block;
-        } else {
-            unsafe {
-                self.free_block(last_heap_base as _, pages * PAGE_4K);
-            }
-        }
-        self.free_size += pages * PAGE_4K;
+        Some(current_heap_base as *mut u8)
     }
 
-    unsafe fn free_block(&mut self, freeing_block: usize, size: usize) {
-        assert!(freeing_block <= self.heap_start + self.mapped_pages * PAGE_4K);
-        assert!(freeing_block + size <= self.heap_start + self.mapped_pages * PAGE_4K);
-
-        let freeing_block = freeing_block as *mut HeapFreeBlock;
-        let freeing_block_start = freeing_block as usize;
-        let freeing_block_end = freeing_block_start + size;
-
-        // find blocks that are either before or after this block
-        let mut prev_block: *mut HeapFreeBlock = core::ptr::null_mut();
-        let mut next_block: *mut HeapFreeBlock = core::ptr::null_mut();
-        let mut closest_prev_block: *mut HeapFreeBlock = core::ptr::null_mut();
-        for block in self.iter_free_blocks() {
-            let block_addr = block as *mut _ as usize;
-            let block_end = block_addr + block.size;
-
-            if block_addr == freeing_block_start {
-                // our block should not be in the free list
-                panic!("double free");
-            }
-
-            // assert that we are not in the middle of a block
-            assert!(
-                (freeing_block_end <= block_addr) || (freeing_block_start >= block_end),
-                "Free block at {:x}..{:x} is in the middle of another block at {:x}..{:x}",
-                freeing_block_start,
-                freeing_block_end,
-                block_addr,
-                block_end
-            );
-
-            if block_end == freeing_block_start {
-                // this block is before the freeing block
-                prev_block = block as _;
-            } else if freeing_block_end == block_addr {
-                // this block is after the freeing block
-                next_block = block as _;
-            }
-
-            if block_addr < freeing_block_start {
-                // this block is before the freeing block
-                if closest_prev_block.is_null() || block_addr > (closest_prev_block as usize) {
-                    closest_prev_block = block as _;
-                }
-            }
-        }
-
-        eprintln!(
-            "prev_block: {:x}, next_block: {:x}",
-            prev_block as usize, next_block as usize
-        );
-
-        if !prev_block.is_null() && !next_block.is_null() {
-            eprintln!("b: prev_block: [{:x}]={:X?}", prev_block as usize, unsafe {
-                &mut *prev_block
-            });
-            eprintln!("b: next_block: [{:x}]={:X?}", next_block as usize, unsafe {
-                &mut *next_block
-            });
-            let new_block = prev_block;
-            // both are not null, so we are in the middle
-            // merge the blocks
-            (*new_block).size += size + (*next_block).size;
-
-            // update the previous block to point to this new subblock instead
-            if !(*next_block).next.is_null() {
-                (*(*next_block).next).prev = new_block;
-            }
-
-            if !(*next_block).prev.is_null() {
-                (*(*next_block).prev).next = new_block;
-            } else {
-                // this is the first block
-                self.free_list_addr = new_block;
-            }
-
-            (*new_block).next = (*next_block).next;
-
-            eprintln!("a: prev_block: [{:x}]={:X?}", prev_block as usize, unsafe {
-                &mut *prev_block
-            });
-            eprintln!("a: next_block: [{:x}]={:X?}", next_block as usize, unsafe {
-                &mut *next_block
-            });
-            eprintln!(
-                "a: free_list_addr: [{:x}]={:X?}",
-                self.free_list_addr as usize,
-                unsafe { &mut *self.free_list_addr }
-            );
-        } else if !prev_block.is_null() {
-            // no blocks after this
-            // merge the blocks easily, we only need to change the size
-            (*prev_block).size += size;
-        } else if !next_block.is_null() {
-            let new_block = freeing_block;
-
-            // replace next with a new size
-            (*new_block).size = (*next_block).size + size;
-            (*new_block).prev = (*next_block).prev;
-            (*new_block).next = (*next_block).next;
-
-            // update references
-            // update the next block to point to this new subblock instead
-            if !(*next_block).next.is_null() {
-                (*(*next_block).next).prev = new_block;
-            }
-            // update the previous block to point to this new subblock instead
-            if !(*next_block).prev.is_null() {
-                (*(*next_block).prev).next = new_block;
-            } else {
-                // this is the first block
-                self.free_list_addr = new_block;
-            }
-
-            eprintln!("a: new-block: [{:x}]={:X?}", new_block as usize, unsafe {
-                &mut *new_block
-            });
-        } else {
-            // no blocks around this
-            // add this to the free list in the correct order
-            if closest_prev_block.is_null() {
-                // this is the first block
-                (*freeing_block).prev = core::ptr::null_mut();
-                (*freeing_block).next = self.free_list_addr;
-                (*freeing_block).size = size;
-
-                // update the next block to point to this new subblock instead
-                if !(*freeing_block).next.is_null() {
-                    (*(*freeing_block).next).prev = freeing_block;
-                }
-
-                self.free_list_addr = freeing_block;
-            } else {
-                // put this after the closest previous block
-                let closest_next_block = (*closest_prev_block).next;
-                (*freeing_block).prev = closest_prev_block;
-                (*freeing_block).next = closest_next_block;
-                (*freeing_block).size = size;
-
-                (*closest_prev_block).next = freeing_block;
-                if !closest_next_block.is_null() {
-                    (*closest_next_block).prev = freeing_block;
-                }
-            }
-        }
+    fn deallocate_pages(&mut self, _pages: usize) -> bool {
+        todo!()
     }
 }
 
 pub struct LockedKernelHeapAllocator {
-    inner: Mutex<KernelHeapAllocator>,
+    inner: OnceLock<Mutex<HeapAllocator<PAGE_4K, PageAllocator>>>,
 }
 
 impl LockedKernelHeapAllocator {
     const fn empty() -> Self {
         Self {
-            inner: Mutex::new(KernelHeapAllocator::empty()),
+            inner: OnceLock::new(),
         }
     }
 
-    #[allow(dead_code)]
-    pub fn debug_free_blocks(&self) {
-        self.inner.lock().debug_free_blocks();
+    fn init_mutex() -> Mutex<HeapAllocator<PAGE_4K, PageAllocator>> {
+        Mutex::new(HeapAllocator::new(PageAllocator::new()))
     }
 
-    #[allow(dead_code)]
-    pub fn stats(&self) -> (usize, usize) {
-        let inner = self.inner.lock();
-        (inner.free_size, inner.used_size)
+    pub fn stats(&self) -> HeapStats {
+        let inner = self.inner.get_or_init(Self::init_mutex).lock();
+        inner.stats()
     }
 }
 
 unsafe impl GlobalAlloc for LockedKernelHeapAllocator {
-    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
-        let mut inner = self.inner.lock();
-
-        // info header
-        let block_info_layout = core::alloc::Layout::new::<AllocatedHeapBlockInfo>();
-
-        let (whole_layout, whole_block_offset) = block_info_layout
-            .extend(layout.align_to(16).unwrap())
-            .unwrap();
-        // at least align to 16 bytes
-        let size_to_allocate = whole_layout.pad_to_align().size();
-
-        eprintln!("Allocating {} bytes", size_to_allocate);
-
-        let free_block = inner.get_free_block(size_to_allocate);
-        eprintln!("Got free block at {:x}", free_block as usize);
-        if free_block.is_null() {
-            return core::ptr::null_mut();
-        }
-
-        let free_block_size = (*free_block).size;
-        let free_block_end = free_block as usize + size_to_allocate;
-        let new_free_block = free_block_end as *mut HeapFreeBlock;
-
-        // we have to make sure that the block after us has enough space to write the metadat
-        // and we won't corrupt the block that comes after (if there is anys)
-        let whole_size = size_to_allocate + mem::size_of::<HeapFreeBlock>();
-
-        // store the actual size of the block
-        // if we needed to extend (since the next free block is to small)
-        // this will include the whole size and not just the size that
-        // we were asked to allocate
-        let mut this_allocation_size = size_to_allocate;
-
-        // do we have empty space left?
-        if free_block_size > whole_size {
-            // update the previous block to point to this new subblock instead
-            (*new_free_block).prev = (*free_block).prev;
-            (*new_free_block).next = (*free_block).next;
-            (*new_free_block).size = free_block_size - size_to_allocate;
-
-            eprintln!("a: prev_block: [{:x}]", (*new_free_block).prev as usize,);
-            eprintln!("a: next_block: [{:x}]", (*new_free_block).next as usize);
-
-            // update the next block to point to this new subblock instead
-            if !(*new_free_block).next.is_null() {
-                (*(*new_free_block).next).prev = new_free_block;
-            }
-
-            // update the previous block to point to this new subblock instead
-            if !(*new_free_block).prev.is_null() {
-                (*(*new_free_block).prev).next = new_free_block;
-            } else {
-                // this is the first block
-                inner.free_list_addr = new_free_block;
-            }
-        } else {
-            // exact size
-            this_allocation_size = free_block_size;
-
-            // update the previous block to point to the next block instead
-            if !(*free_block).prev.is_null() {
-                (*(*free_block).prev).next = (*free_block).next;
-            } else {
-                // this is the first block
-                inner.free_list_addr = (*free_block).next;
-            }
-            if !(*free_block).next.is_null() {
-                (*(*free_block).next).prev = (*free_block).prev;
-            }
-        }
-        // drop inner early
-        inner.free_size -= this_allocation_size;
-        inner.used_size += this_allocation_size;
-
-        // TODO: add flag to control when to enable this runtime checking
-        if inner.check_issues() {
-            println!("alloc: {:x}..{:x}", free_block as usize, free_block_end);
-            println!("alloc: Issue detected");
-            inner.debug_free_blocks();
-            panic!(); // mostly won't reach here since debug_free_blocks will not finish
-        }
-
-        drop(inner);
-
-        // work on the pointer and add the info of the block before it
-        // so we can use it to deallocate later
-        let base = free_block as usize;
-        let possible_next_offset = align_up(base, layout.align()) - base;
-        let allocated_block_offset = if possible_next_offset < KERNEL_HEAP_BLOCK_INFO_SIZE {
-            possible_next_offset + KERNEL_HEAP_BLOCK_INFO_SIZE
-        } else {
-            possible_next_offset
-        };
-        assert!(allocated_block_offset >= KERNEL_HEAP_BLOCK_INFO_SIZE);
-        assert!(allocated_block_offset <= whole_block_offset);
-        let allocated_ptr = (free_block as *mut u8).add(allocated_block_offset);
-        let allocated_block_info =
-            allocated_ptr.sub(KERNEL_HEAP_BLOCK_INFO_SIZE) as *mut AllocatedHeapBlockInfo;
-        // make sure we are aligned
-        assert!(
-            is_aligned(allocated_ptr as _, layout.align(),),
-            "base_block={allocated_block_info:p}, offset={allocated_block_offset}, ptr={allocated_ptr:?}, layout={layout:?}, should_be_addr={:x}",
-            align_up(allocated_block_info as usize, layout.align())
-        );
-
-        // write the info header
-        (*allocated_block_info).magic = KERNEL_HEAP_MAGIC;
-        (*allocated_block_info).size = this_allocation_size;
-        (*allocated_block_info).pre_padding = allocated_block_offset;
-
-        allocated_ptr
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.inner
+            .get_or_init(Self::init_mutex)
+            .lock()
+            .alloc(layout)
     }
 
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
-        assert!(!ptr.is_null());
-
-        // info header
-        let base_layout = core::alloc::Layout::new::<AllocatedHeapBlockInfo>();
-
-        let (whole_layout, _) = base_layout.extend(layout.align_to(16).unwrap()).unwrap();
-        let size_to_free_from_layout = whole_layout.pad_to_align().size();
-
-        let allocated_block_info =
-            ptr.sub(KERNEL_HEAP_BLOCK_INFO_SIZE) as *mut AllocatedHeapBlockInfo;
-
-        eprintln!(
-            "deallocating {:p}, size={}",
-            allocated_block_info, size_to_free_from_layout
-        );
-        assert_eq!((*allocated_block_info).magic, KERNEL_HEAP_MAGIC);
-        // This could be more than the layout size, because
-        // we might increase the size of the block a bit to not leave
-        // free blocks that are too small (see `alloc``)
-        assert!((*allocated_block_info).size >= size_to_free_from_layout);
-        assert!((*allocated_block_info).pre_padding >= KERNEL_HEAP_BLOCK_INFO_SIZE);
-        let this_allocation_size = (*allocated_block_info).size;
-
-        let freeing_block = ptr.sub((*allocated_block_info).pre_padding) as usize;
-
-        let mut inner = self.inner.lock();
-        inner.free_block(freeing_block, this_allocation_size);
-        inner.used_size -= this_allocation_size;
-        inner.free_size += this_allocation_size;
-
-        // TODO: add flag to control when to enable this runtime checking
-        if inner.check_issues() {
-            println!(
-                "dealloc: {:x}..{:x}",
-                freeing_block,
-                freeing_block + this_allocation_size
-            );
-            println!("dealloc: Issue detected");
-            inner.debug_free_blocks();
-            panic!(); // mostly won't reach here since debug_free_blocks will not finish
-        }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner
+            .get_or_init(Self::init_mutex)
+            .lock()
+            .dealloc(ptr, layout)
     }
 }

--- a/libraries/increasing_heap_allocator/Cargo.toml
+++ b/libraries/increasing_heap_allocator/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
-name = "kernel"
+name = "increasing_heap_allocator"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kernel_user_link = { path = "../libraries/kernel_user_link" }
-increasing_heap_allocator = { path = "../libraries/increasing_heap_allocator" }

--- a/libraries/increasing_heap_allocator/src/allocator.rs
+++ b/libraries/increasing_heap_allocator/src/allocator.rs
@@ -1,0 +1,464 @@
+use core::mem;
+
+use crate::{is_aligned, HeapStats, PageAllocatorProvider};
+
+use super::align_up;
+
+const HEAP_MAGIC: u32 = 0xF0B0CAFE;
+
+#[repr(C, align(16))]
+struct AllocatedHeapBlockInfo {
+    magic: u32,
+    size: usize,
+    pre_padding: usize,
+}
+
+const KERNEL_HEAP_BLOCK_INFO_SIZE: usize = mem::size_of::<AllocatedHeapBlockInfo>();
+
+#[derive(Debug)]
+struct HeapFreeBlock {
+    prev: *mut HeapFreeBlock,
+    next: *mut HeapFreeBlock,
+    // including this header
+    size: usize,
+}
+
+pub struct HeapAllocator<const PAGE_SIZE: usize, T: PageAllocatorProvider<PAGE_SIZE>> {
+    heap_start: usize,
+    total_heap_size: usize,
+    free_list_addr: *mut HeapFreeBlock,
+    free_size: usize,
+    used_size: usize,
+    page_allocator: T,
+}
+
+unsafe impl<const PAGE_SIZE: usize, T: PageAllocatorProvider<PAGE_SIZE>> Send
+    for HeapAllocator<PAGE_SIZE, T>
+{
+}
+
+impl<const PAGE_SIZE: usize, T> HeapAllocator<PAGE_SIZE, T>
+where
+    T: PageAllocatorProvider<PAGE_SIZE>,
+{
+    fn is_free_blocks_in_cycle(&self) -> bool {
+        // use floyd algorithm to detect if we are in cycle
+        let mut slow = self.free_list_addr;
+        let mut fast = self.free_list_addr;
+
+        // advance fast first
+        if fast.is_null() {
+            return false;
+        } else {
+            fast = unsafe { (*fast).next };
+        }
+
+        while fast != slow {
+            if fast.is_null() {
+                return false;
+            } else {
+                fast = unsafe { (*fast).next };
+            }
+            if fast.is_null() {
+                return false;
+            } else {
+                fast = unsafe { (*fast).next };
+            }
+
+            if slow.is_null() {
+                return false;
+            } else {
+                slow = unsafe { (*slow).next };
+            }
+        }
+
+        true
+    }
+
+    fn check_free_blocks(&self) -> bool {
+        let mut forward_count = 0;
+        let mut last: *mut HeapFreeBlock = core::ptr::null_mut();
+        for block in self.iter_free_blocks() {
+            forward_count += 1;
+            last = block as _;
+        }
+
+        let mut backward_count = 0;
+        if !last.is_null() {
+            // go back to the first block
+            while !last.is_null() {
+                backward_count += 1;
+                last = unsafe { (*last).prev };
+            }
+        }
+
+        forward_count != backward_count
+    }
+
+    fn check_issues(&self) -> bool {
+        self.is_free_blocks_in_cycle() || self.check_free_blocks()
+    }
+
+    fn get_free_block(&mut self, size: usize) -> *mut HeapFreeBlock {
+        if self.total_heap_size == 0 {
+            let size = align_up(size, PAGE_SIZE);
+            self.allocate_more_pages(size / PAGE_SIZE);
+            // call recursively
+            return self.get_free_block(size);
+        }
+        // find best block
+        let mut best_block: *mut HeapFreeBlock = core::ptr::null_mut();
+        for block in self.iter_free_blocks() {
+            if block.size >= size
+                && (best_block.is_null() || block.size < unsafe { (*best_block).size })
+            {
+                best_block = block as _;
+            }
+        }
+
+        if best_block.is_null() {
+            // no block found, allocate more pages
+            let size = align_up(size, PAGE_SIZE);
+            self.allocate_more_pages(size / PAGE_SIZE);
+            // call recursively
+            return self.get_free_block(size);
+        }
+
+        best_block
+    }
+
+    fn iter_free_blocks(&self) -> impl Iterator<Item = &mut HeapFreeBlock> {
+        let mut current_block = self.free_list_addr;
+        core::iter::from_fn(move || {
+            if current_block.is_null() {
+                None
+            } else {
+                let block = current_block;
+                current_block = unsafe { (*current_block).next };
+                Some(unsafe { &mut *block })
+            }
+        })
+    }
+
+    /// Allocates more pages and add them to the free list
+    fn allocate_more_pages(&mut self, pages: usize) {
+        assert!(pages > 0);
+
+        let new_heap_start = if self.total_heap_size == 0 {
+            // first allocation
+            self.heap_start = self.page_allocator.allocate_pages(pages).unwrap() as usize;
+            self.heap_start
+        } else {
+            // allocate more pages
+            self.page_allocator.allocate_pages(pages).unwrap() as usize
+        };
+
+        self.total_heap_size += pages * PAGE_SIZE;
+
+        // add to the free list (fast path)
+        if self.free_list_addr.is_null() {
+            // no free list for now, add this as the very first free entry
+            let free_block = new_heap_start as *mut HeapFreeBlock;
+
+            unsafe {
+                (*free_block).prev = core::ptr::null_mut();
+                (*free_block).next = core::ptr::null_mut();
+                (*free_block).size = pages * PAGE_SIZE;
+            }
+
+            self.free_list_addr = free_block;
+        } else {
+            unsafe {
+                self.free_block(new_heap_start as _, pages * PAGE_SIZE);
+            }
+        }
+        self.free_size += pages * PAGE_SIZE;
+    }
+
+    unsafe fn free_block(&mut self, freeing_block: usize, size: usize) {
+        assert!(freeing_block <= self.heap_start + self.total_heap_size);
+        assert!(freeing_block + size <= self.heap_start + self.total_heap_size);
+
+        let freeing_block = freeing_block as *mut HeapFreeBlock;
+        let freeing_block_start = freeing_block as usize;
+        let freeing_block_end = freeing_block_start + size;
+
+        // find blocks that are either before or after this block
+        let mut prev_block: *mut HeapFreeBlock = core::ptr::null_mut();
+        let mut next_block: *mut HeapFreeBlock = core::ptr::null_mut();
+        let mut closest_prev_block: *mut HeapFreeBlock = core::ptr::null_mut();
+        for block in self.iter_free_blocks() {
+            let block_addr = block as *mut _ as usize;
+            let block_end = block_addr + block.size;
+
+            if block_addr == freeing_block_start {
+                // our block should not be in the free list
+                panic!("double free");
+            }
+
+            // assert that we are not in the middle of a block
+            assert!(
+                (freeing_block_end <= block_addr) || (freeing_block_start >= block_end),
+                "Free block at {:x}..{:x} is in the middle of another block at {:x}..{:x}",
+                freeing_block_start,
+                freeing_block_end,
+                block_addr,
+                block_end
+            );
+
+            if block_end == freeing_block_start {
+                // this block is before the freeing block
+                prev_block = block as _;
+            } else if freeing_block_end == block_addr {
+                // this block is after the freeing block
+                next_block = block as _;
+            }
+
+            if block_addr < freeing_block_start {
+                // this block is before the freeing block
+                if closest_prev_block.is_null() || block_addr > (closest_prev_block as usize) {
+                    closest_prev_block = block as _;
+                }
+            }
+        }
+
+        if !prev_block.is_null() && !next_block.is_null() {
+            let new_block = prev_block;
+            // both are not null, so we are in the middle
+            // merge the blocks
+            (*new_block).size += size + (*next_block).size;
+
+            // update the previous block to point to this new subblock instead
+            if !(*next_block).next.is_null() {
+                (*(*next_block).next).prev = new_block;
+            }
+
+            if !(*next_block).prev.is_null() {
+                (*(*next_block).prev).next = new_block;
+            } else {
+                // this is the first block
+                self.free_list_addr = new_block;
+            }
+
+            (*new_block).next = (*next_block).next;
+        } else if !prev_block.is_null() {
+            // no blocks after this
+            // merge the blocks easily, we only need to change the size
+            (*prev_block).size += size;
+        } else if !next_block.is_null() {
+            let new_block = freeing_block;
+
+            // replace next with a new size
+            (*new_block).size = (*next_block).size + size;
+            (*new_block).prev = (*next_block).prev;
+            (*new_block).next = (*next_block).next;
+
+            // update references
+            // update the next block to point to this new subblock instead
+            if !(*next_block).next.is_null() {
+                (*(*next_block).next).prev = new_block;
+            }
+            // update the previous block to point to this new subblock instead
+            if !(*next_block).prev.is_null() {
+                (*(*next_block).prev).next = new_block;
+            } else {
+                // this is the first block
+                self.free_list_addr = new_block;
+            }
+        } else {
+            // no blocks around this
+            // add this to the free list in the correct order
+            if closest_prev_block.is_null() {
+                // this is the first block
+                (*freeing_block).prev = core::ptr::null_mut();
+                (*freeing_block).next = self.free_list_addr;
+                (*freeing_block).size = size;
+
+                // update the next block to point to this new subblock instead
+                if !(*freeing_block).next.is_null() {
+                    (*(*freeing_block).next).prev = freeing_block;
+                }
+
+                self.free_list_addr = freeing_block;
+            } else {
+                // put this after the closest previous block
+                let closest_next_block = (*closest_prev_block).next;
+                (*freeing_block).prev = closest_prev_block;
+                (*freeing_block).next = closest_next_block;
+                (*freeing_block).size = size;
+
+                (*closest_prev_block).next = freeing_block;
+                if !closest_next_block.is_null() {
+                    (*closest_next_block).prev = freeing_block;
+                }
+            }
+        }
+    }
+}
+
+// public interface
+impl<const PAGE_SIZE: usize, T> HeapAllocator<PAGE_SIZE, T>
+where
+    T: PageAllocatorProvider<PAGE_SIZE>,
+{
+    pub fn new(page_allocator: T) -> Self {
+        Self {
+            heap_start: 0,
+            free_list_addr: core::ptr::null_mut(),
+            total_heap_size: 0,
+            free_size: 0,
+            used_size: 0,
+            page_allocator,
+        }
+    }
+
+    pub fn stats(&self) -> HeapStats {
+        HeapStats {
+            allocated: self.used_size,
+            free_size: self.free_size,
+            heap_size: self.total_heap_size,
+        }
+    }
+
+    pub fn debug_free_blocks(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        self.iter_free_blocks()
+            .map(|block| (block as *mut _ as usize, block.size))
+    }
+
+    /// # Safety
+    /// Check [`core::alloc::GlobalAlloc::alloc`] for more info
+    pub unsafe fn alloc(&mut self, layout: core::alloc::Layout) -> *mut u8 {
+        // info header
+        let block_info_layout = core::alloc::Layout::new::<AllocatedHeapBlockInfo>();
+
+        let (whole_layout, whole_block_offset) = block_info_layout
+            .extend(layout.align_to(16).unwrap())
+            .unwrap();
+        // at least align to 16 bytes
+        let size_to_allocate = whole_layout.pad_to_align().size();
+
+        let free_block = self.get_free_block(size_to_allocate);
+
+        if free_block.is_null() {
+            return core::ptr::null_mut();
+        }
+
+        let free_block_size = (*free_block).size;
+        let free_block_end = free_block as usize + size_to_allocate;
+        let new_free_block = free_block_end as *mut HeapFreeBlock;
+
+        // we have to make sure that the block after us has enough space to write the metadat
+        // and we won't corrupt the block that comes after (if there is anys)
+        let whole_size = size_to_allocate + mem::size_of::<HeapFreeBlock>();
+
+        // store the actual size of the block
+        // if we needed to extend (since the next free block is to small)
+        // this will include the whole size and not just the size that
+        // we were asked to allocate
+        let mut this_allocation_size = size_to_allocate;
+
+        // do we have empty space left?
+        if free_block_size > whole_size {
+            // update the previous block to point to this new subblock instead
+            (*new_free_block).prev = (*free_block).prev;
+            (*new_free_block).next = (*free_block).next;
+            (*new_free_block).size = free_block_size - size_to_allocate;
+
+            // update the next block to point to this new subblock instead
+            if !(*new_free_block).next.is_null() {
+                (*(*new_free_block).next).prev = new_free_block;
+            }
+
+            // update the previous block to point to this new subblock instead
+            if !(*new_free_block).prev.is_null() {
+                (*(*new_free_block).prev).next = new_free_block;
+            } else {
+                // this is the first block
+                self.free_list_addr = new_free_block;
+            }
+        } else {
+            // exact size
+            this_allocation_size = free_block_size;
+
+            // update the previous block to point to the next block instead
+            if !(*free_block).prev.is_null() {
+                (*(*free_block).prev).next = (*free_block).next;
+            } else {
+                // this is the first block
+                self.free_list_addr = (*free_block).next;
+            }
+            if !(*free_block).next.is_null() {
+                (*(*free_block).next).prev = (*free_block).prev;
+            }
+        }
+        self.free_size -= this_allocation_size;
+        self.used_size += this_allocation_size;
+
+        // TODO: add flag to control when to enable this runtime checking
+        if self.check_issues() {
+            panic!("Found issues in `alloc`");
+        }
+
+        // work on the pointer and add the info of the block before it
+        // so we can use it to deallocate later
+        let base = free_block as usize;
+        let possible_next_offset = align_up(base, layout.align()) - base;
+        let allocated_block_offset = if possible_next_offset < KERNEL_HEAP_BLOCK_INFO_SIZE {
+            possible_next_offset + KERNEL_HEAP_BLOCK_INFO_SIZE
+        } else {
+            possible_next_offset
+        };
+        assert!(allocated_block_offset >= KERNEL_HEAP_BLOCK_INFO_SIZE);
+        assert!(allocated_block_offset <= whole_block_offset);
+        let allocated_ptr = (free_block as *mut u8).add(allocated_block_offset);
+        let allocated_block_info =
+            allocated_ptr.sub(KERNEL_HEAP_BLOCK_INFO_SIZE) as *mut AllocatedHeapBlockInfo;
+        // make sure we are aligned
+        assert!(
+                    is_aligned(allocated_ptr as _, layout.align()),
+                    "base_block={allocated_block_info:p}, offset={allocated_block_offset}, ptr={allocated_ptr:?}, layout={layout:?}, should_be_addr={:x}",
+                    align_up(allocated_block_info as usize, layout.align())
+                );
+
+        // write the info header
+        (*allocated_block_info).magic = HEAP_MAGIC;
+        (*allocated_block_info).size = this_allocation_size;
+        (*allocated_block_info).pre_padding = allocated_block_offset;
+
+        allocated_ptr
+    }
+
+    /// # Safety
+    /// Check [`core::alloc::GlobalAlloc::dealloc`] for more info
+    pub unsafe fn dealloc(&mut self, ptr: *mut u8, layout: core::alloc::Layout) {
+        assert!(!ptr.is_null());
+
+        // info header
+        let base_layout = core::alloc::Layout::new::<AllocatedHeapBlockInfo>();
+
+        let (whole_layout, _) = base_layout.extend(layout.align_to(16).unwrap()).unwrap();
+        let size_to_free_from_layout = whole_layout.pad_to_align().size();
+
+        let allocated_block_info =
+            ptr.sub(KERNEL_HEAP_BLOCK_INFO_SIZE) as *mut AllocatedHeapBlockInfo;
+
+        assert_eq!((*allocated_block_info).magic, HEAP_MAGIC);
+        // This could be more than the layout size, because
+        // we might increase the size of the block a bit to not leave
+        // free blocks that are too small (see `alloc``)
+        assert!((*allocated_block_info).size >= size_to_free_from_layout);
+        assert!((*allocated_block_info).pre_padding >= KERNEL_HEAP_BLOCK_INFO_SIZE);
+        let this_allocation_size = (*allocated_block_info).size;
+
+        let freeing_block = ptr.sub((*allocated_block_info).pre_padding) as usize;
+
+        self.free_block(freeing_block, this_allocation_size);
+        self.used_size -= this_allocation_size;
+        self.free_size += this_allocation_size;
+
+        // TODO: add flag to control when to enable this runtime checking
+        if self.check_issues() {
+            panic!("Found issues in `dealloc`");
+        }
+    }
+}

--- a/libraries/increasing_heap_allocator/src/lib.rs
+++ b/libraries/increasing_heap_allocator/src/lib.rs
@@ -13,6 +13,7 @@ const fn is_aligned(addr: usize, alignment: usize) -> bool {
     (addr & (alignment - 1)) == 0
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct HeapStats {
     pub allocated: usize,
     pub free_size: usize,

--- a/libraries/increasing_heap_allocator/src/lib.rs
+++ b/libraries/increasing_heap_allocator/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+pub use allocator::HeapAllocator;
+
+mod allocator;
+
+// helper functions
+const fn align_up(addr: usize, alignment: usize) -> usize {
+    (addr + alignment - 1) & !(alignment - 1)
+}
+
+const fn is_aligned(addr: usize, alignment: usize) -> bool {
+    (addr & (alignment - 1)) == 0
+}
+
+pub struct HeapStats {
+    pub allocated: usize,
+    pub free_size: usize,
+    pub heap_size: usize,
+}
+
+pub trait PageAllocatorProvider<const PAGE_SIZE: usize> {
+    /// Return the start address of the new allocated heap
+    fn allocate_pages(&mut self, pages: usize) -> Option<*mut u8>;
+    /// Deallocate pages from the end of the heap
+    /// Return true if the deallocation was successful
+    fn deallocate_pages(&mut self, pages: usize) -> bool;
+}

--- a/libraries/user_std/Cargo.toml
+++ b/libraries/user_std/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "init"
+name = "user_std"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kernel_user_link = { path = "../../libraries/kernel_user_link" }
-user_std = { path = "../../libraries/user_std" }
+increasing_heap_allocator = { path = "../increasing_heap_allocator" }
+kernel_user_link = { path = "../kernel_user_link" }

--- a/libraries/user_std/src/alloc.rs
+++ b/libraries/user_std/src/alloc.rs
@@ -1,0 +1,101 @@
+use core::alloc::{GlobalAlloc, Layout};
+
+use increasing_heap_allocator::{HeapAllocator, HeapStats, PageAllocatorProvider};
+use kernel_user_link::{
+    call_syscall,
+    syscalls::{SyscallError, SYS_INC_HEAP},
+};
+
+use crate::sync::{once::OnceLock, spin::mutex::Mutex};
+
+pub extern crate alloc;
+
+const PAGE_4K: usize = 0x1000;
+
+unsafe fn inc_dec_heap(increment: isize) -> Result<*mut u8, SyscallError> {
+    unsafe {
+        call_syscall!(
+            SYS_INC_HEAP,
+            increment as u64, // increment
+        )
+        .map(|addr| addr as *mut u8)
+    }
+}
+
+#[global_allocator]
+pub static ALLOCATOR: LockedKernelHeapAllocator = LockedKernelHeapAllocator::empty();
+
+struct PageAllocator {
+    heap_start: usize,
+    mapped_pages: usize,
+}
+
+impl PageAllocator {
+    fn new() -> Self {
+        Self {
+            heap_start: unsafe { inc_dec_heap(0).unwrap() as usize },
+            mapped_pages: 0,
+        }
+    }
+}
+
+impl PageAllocatorProvider<PAGE_4K> for PageAllocator {
+    fn allocate_pages(&mut self, pages: usize) -> Option<*mut u8> {
+        // eprintln!("Allocating {} pages", pages);
+        assert!(pages > 0);
+
+        let last_heap_base = self.heap_start + self.mapped_pages * PAGE_4K;
+        let new_addr = unsafe { inc_dec_heap((pages * PAGE_4K) as isize) };
+
+        let Ok(new_addr) = new_addr else {
+            return None;
+        };
+        assert!(new_addr as usize == last_heap_base);
+
+        self.mapped_pages += pages;
+
+        Some(new_addr)
+    }
+
+    fn deallocate_pages(&mut self, _pages: usize) -> bool {
+        todo!()
+    }
+}
+
+pub struct LockedKernelHeapAllocator {
+    inner: OnceLock<Mutex<HeapAllocator<PAGE_4K, PageAllocator>>>,
+}
+
+impl LockedKernelHeapAllocator {
+    const fn empty() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    fn init_mutex() -> Mutex<HeapAllocator<PAGE_4K, PageAllocator>> {
+        Mutex::new(HeapAllocator::new(PageAllocator::new()))
+    }
+
+    #[allow(dead_code)]
+    pub fn stats(&self) -> HeapStats {
+        let inner = self.inner.get_or_init(Self::init_mutex).lock();
+        inner.stats()
+    }
+}
+
+unsafe impl GlobalAlloc for LockedKernelHeapAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.inner
+            .get_or_init(Self::init_mutex)
+            .lock()
+            .alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner
+            .get_or_init(Self::init_mutex)
+            .lock()
+            .dealloc(ptr, layout)
+    }
+}

--- a/libraries/user_std/src/lib.rs
+++ b/libraries/user_std/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+
+pub mod alloc;
+mod sync;

--- a/libraries/user_std/src/sync/mod.rs
+++ b/libraries/user_std/src/sync/mod.rs
@@ -1,0 +1,2 @@
+pub mod once;
+pub mod spin;

--- a/libraries/user_std/src/sync/once.rs
+++ b/libraries/user_std/src/sync/once.rs
@@ -1,0 +1,226 @@
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    marker::PhantomData,
+    mem::MaybeUninit,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+const ONCE_STATE_INIT: usize = 0;
+const ONCE_STATE_RUNNING: usize = 1;
+const ONCE_STATE_DONE: usize = 2;
+
+struct Once {
+    state: AtomicUsize,
+}
+
+impl Once {
+    pub const fn new() -> Self {
+        Once {
+            state: AtomicUsize::new(ONCE_STATE_INIT),
+        }
+    }
+
+    fn is_completed(&self) -> bool {
+        self.state.load(Ordering::Relaxed) == ONCE_STATE_DONE
+    }
+
+    pub fn call(&self, f: impl FnOnce()) {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            match state {
+                ONCE_STATE_INIT => {
+                    // Try to transition to RUNNING state.
+                    match self.state.compare_exchange_weak(
+                        ONCE_STATE_INIT,
+                        ONCE_STATE_RUNNING,
+                        Ordering::Acquire,
+                        Ordering::Relaxed,
+                    ) {
+                        Ok(_) => {
+                            // We've successfully transitioned to RUNNING state.
+                            // Run the closure.
+                            f();
+
+                            // Transition to DONE state.
+                            self.state.store(ONCE_STATE_DONE, Ordering::Release);
+                            return;
+                        }
+                        Err(new) => {
+                            // We failed to transition to RUNNING state.
+                            state = new;
+                            continue;
+                        }
+                    }
+                }
+                ONCE_STATE_RUNNING => {
+                    panic!("Once::call already running");
+                }
+                ONCE_STATE_DONE => return,
+                _ => unreachable!("state is never set to invalid values"),
+            }
+        }
+    }
+}
+
+pub struct OnceLock<T> {
+    once: Once,
+    // Whether or not the value is initialized is tracked by `once.is_completed()`.
+    value: UnsafeCell<MaybeUninit<T>>,
+    /// `PhantomData` to make sure dropck understands we're dropping T in our Drop impl.
+    ///
+    /// ```compile_fail,E0597
+    /// use std::sync::OnceLock;
+    ///
+    /// struct A<'a>(&'a str);
+    ///
+    /// impl<'a> Drop for A<'a> {
+    ///     fn drop(&mut self) {}
+    /// }
+    ///
+    /// let cell = OnceLock::new();
+    /// {
+    ///     let s = String::new();
+    ///     let _ = cell.set(A(&s));
+    /// }
+    /// ```
+    _marker: PhantomData<T>,
+}
+
+unsafe impl<T: Sync + Send> Sync for OnceLock<T> {}
+unsafe impl<T: Send> Send for OnceLock<T> {}
+
+impl Default for Once {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for OnceLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_tuple("OnceLock");
+        match self.try_get() {
+            Some(v) => d.field(v),
+            None => d.field(&format_args!("<uninit>")),
+        };
+        d.finish()
+    }
+}
+
+impl<T: Clone> Clone for OnceLock<T> {
+    #[inline]
+    fn clone(&self) -> OnceLock<T> {
+        let cell = Self::new();
+        if let Some(value) = self.try_get() {
+            match cell.set(value.clone()) {
+                Ok(()) => (),
+                Err(_) => unreachable!(),
+            }
+        }
+        cell
+    }
+}
+
+#[allow(dead_code)]
+impl<T> OnceLock<T> {
+    pub const fn new() -> Self {
+        OnceLock {
+            once: Once::new(),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn set(&self, value: T) -> Result<(), T> {
+        if self.is_completed() {
+            return Err(value);
+        }
+        self.init(|| Ok(value))
+    }
+
+    pub fn get(&self) -> &T {
+        if self.once.is_completed() {
+            unsafe { self.get_unchecked() }
+        } else {
+            panic!("OnceLock::get called before OnceLock::set");
+        }
+    }
+
+    pub fn try_get(&self) -> Option<&T> {
+        if self.once.is_completed() {
+            Some(unsafe { self.get_unchecked() })
+        } else {
+            None
+        }
+    }
+
+    pub fn get_or_init<F>(&self, f: F) -> &T
+    where
+        F: FnOnce() -> T,
+    {
+        match self.get_or_try_init(|| Ok::<T, ()>(f())) {
+            Ok(val) => val,
+            Err(_) => panic!(),
+        }
+    }
+
+    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        // Fast path check
+        // NOTE: We need to perform an acquire on the state in this method
+        // in order to correctly synchronize `LazyLock::force`. This is
+        // currently done by calling `self.get()`, which in turn calls
+        // `self.is_initialized()`, which in turn performs the acquire.
+        if let Some(value) = self.try_get() {
+            return Ok(value);
+        }
+        self.init(f)?;
+
+        debug_assert!(self.is_completed());
+
+        // SAFETY: The inner value has been initialized
+        Ok(unsafe { self.get_unchecked() })
+    }
+
+    #[cold]
+    fn init<F, E>(&self, f: F) -> Result<(), E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        let mut res: Result<(), E> = Ok(());
+        let slot = &self.value;
+
+        // Ignore poisoning from other threads
+        // If another thread panics, then we'll be able to run our closure
+        self.once.call(|| match f() {
+            Ok(value) => {
+                unsafe { (*slot.get()).write(value) };
+            }
+            Err(e) => {
+                res = Err(e);
+            }
+        });
+        res
+    }
+
+    unsafe fn get_unchecked(&self) -> &T {
+        debug_assert!(self.once.is_completed());
+        (*self.value.get()).assume_init_ref()
+    }
+
+    fn is_completed(&self) -> bool {
+        self.once.is_completed()
+    }
+}
+
+impl<T> Drop for OnceLock<T> {
+    fn drop(&mut self) {
+        if self.once.is_completed() {
+            unsafe {
+                (*self.value.get()).assume_init_drop();
+            }
+        }
+    }
+}

--- a/libraries/user_std/src/sync/spin/lock.rs
+++ b/libraries/user_std/src/sync/spin/lock.rs
@@ -1,0 +1,41 @@
+use core::{
+    hint,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+/// A raw spin lock, only provides `lock` and `unlock` and waiting for the lock
+///
+/// This is an unsafe lock, it doesn't have any protection against deadlocks, or multiple locking
+/// A safe wrappers are implemented with `Mutex` and `ReMutex`
+pub(super) struct Lock {
+    locked: AtomicBool,
+}
+
+impl Lock {
+    pub const fn new() -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    pub fn lock(&self) {
+        while !self.try_lock() {
+            hint::spin_loop();
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    /// Try to lock the lock, returns true if successful
+    pub fn try_lock(&self) -> bool {
+        self.locked
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    /// SAFETY: the caller must assure that there is only one accessor for this lock
+    ///         we don't want multiple unlocks, it doesn't make sense for this Lock (check `super::remutex::ReMutex`)
+    pub unsafe fn unlock(&self) {
+        self.locked.store(false, Ordering::Release);
+    }
+}

--- a/libraries/user_std/src/sync/spin/mod.rs
+++ b/libraries/user_std/src/sync/spin/mod.rs
@@ -1,0 +1,2 @@
+mod lock;
+pub mod mutex;

--- a/libraries/user_std/src/sync/spin/mutex.rs
+++ b/libraries/user_std/src/sync/spin/mutex.rs
@@ -1,0 +1,133 @@
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+
+use super::lock;
+
+pub struct Mutex<T: ?Sized> {
+    lock: lock::Lock,
+    data: UnsafeCell<T>,
+}
+
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+
+impl<T> fmt::Debug for Mutex<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("Mutex");
+        if let Some(data) = self.try_lock() {
+            s.field("data", &data);
+        } else {
+            s.field("data", &"[locked]");
+        }
+        s.finish()
+    }
+}
+
+#[must_use]
+pub struct MutexGuard<'a, T: ?Sized + 'a> {
+    lock: &'a Mutex<T>,
+    marker: PhantomData<*const ()>, // !Send
+}
+
+unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
+
+impl<T> fmt::Debug for MutexGuard<'_, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+impl<T> Mutex<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            lock: lock::Lock::new(),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock(&self) -> MutexGuard<T> {
+        // SAFETY: we are the only accessor, and we are locking it, its never locked again until unlocked
+        self.lock.lock();
+        MutexGuard {
+            lock: self,
+            marker: PhantomData,
+        }
+    }
+
+    pub fn try_lock(&self) -> Option<MutexGuard<T>> {
+        if self.lock.try_lock() {
+            Some(MutexGuard {
+                lock: self,
+                marker: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// A special method to allow accessing the variable inside
+    /// the lock after locking it.
+    ///
+    /// The difference between this and using `Deref` is that
+    /// the lifetime of the returned reference is tied to main value of the lock.
+    #[allow(dead_code)]
+    pub fn run_with<'a, R>(&'a self, f: impl FnOnce(&'a T) -> R) -> R {
+        let guard: MutexGuard<'a, T> = self.lock();
+        let d = unsafe { guard.lock.data.get().as_ref().unwrap() };
+        f(d)
+    }
+
+    /// A special method to allow accessing the variable inside
+    /// the lock after locking it.
+    ///
+    /// The difference between this and using `DerefMut` is that
+    /// the lifetime of the returned reference is tied to main value of the lock.
+    #[allow(dead_code)]
+    pub fn run_with_mut<'a, R>(&'a self, f: impl FnOnce(&'a mut T) -> R) -> R {
+        let guard: MutexGuard<'a, T> = self.lock();
+        let d = unsafe { guard.lock.data.get().as_mut().unwrap() };
+        f(d)
+    }
+
+    /// We know statically that no one else is accessing the lock, so we can
+    /// just return a reference to the data without acquiring the lock.
+    #[allow(dead_code)]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.data.get_mut()
+    }
+}
+
+impl<T> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: the mutex is locked, we are the only accessors,
+        //         and the pointer is valid, since it was generated for a valid T
+        unsafe { self.lock.data.get().as_ref().unwrap() }
+    }
+}
+
+impl<T> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: the mutex is locked, we are the only accessors,
+        //         and the pointer is valid, since it was generated for a valid T
+        unsafe { self.lock.data.get().as_mut().unwrap() }
+    }
+}
+
+impl<T: ?Sized> Drop for MutexGuard<'_, T> {
+    fn drop(&mut self) {
+        // SAFETY: the mutex is locked, we are the only accessor
+        unsafe { self.lock.lock.unlock() };
+    }
+}

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -3,19 +3,22 @@
 
 use core::ffi::{c_char, CStr};
 
+use user_std::alloc::alloc;
+
+use alloc::format;
 use kernel_user_link::{
     call_syscall,
-    syscalls::{SYS_EXIT, SYS_INC_HEAP, SYS_SPAWN, SYS_WRITE},
+    syscalls::{SYS_EXIT, SYS_SPAWN, SYS_WRITE},
     FD_STDOUT,
 };
 
-fn write_to_stdout(s: &CStr) {
+fn write_to_stdout(s: &[u8]) {
     unsafe {
         call_syscall!(
             SYS_WRITE,
-            FD_STDOUT,                 // fd
-            s.as_ptr() as u64,         // buf
-            s.to_bytes().len() as u64  // size
+            FD_STDOUT,         // fd
+            s.as_ptr() as u64, // buf
+            s.len() as u64     // size
         )
         .unwrap();
     }
@@ -43,105 +46,22 @@ fn spawn(path: &CStr, argv: &[*const c_char]) -> u64 {
     }
 }
 
-fn allocate_heap(size: usize) -> *mut u8 {
-    unsafe {
-        call_syscall!(
-            SYS_INC_HEAP,
-            size as u64, // increment
-        )
-        .unwrap() as *mut u8
-    }
-}
-
-fn get_heap_end_ptr() -> *mut u8 {
-    unsafe {
-        call_syscall!(
-            SYS_INC_HEAP,
-            0, // increment
-        )
-        .unwrap() as *mut u8
-    }
-}
-
-fn convert_to_string(mut number: i64, radix: u8, buffer: &mut [u8]) -> usize {
-    assert!((2..=16).contains(&radix));
-    const RADIX_CHARS: &[u8] = b"0123456789ABCDEF";
-
-    let mut i = 0;
-    if number < 0 {
-        buffer[i] = b'-';
-        i += 1;
-        number = -number;
-    }
-    let mut n = number as u64;
-    if n == 0 {
-        buffer[i] = b'0';
-        i += 1;
-    } else {
-        let mut len = 0;
-        while n > 0 {
-            len += 1;
-            n /= radix as u64;
-        }
-        let mut n = number as u64;
-        while n > 0 {
-            i += 1;
-            buffer[len - i] = RADIX_CHARS[(n % radix as u64) as usize];
-            n /= radix as u64;
-        }
-    }
-    i
-}
-
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     // we are in `init` now
-    // create some delay
-    write_to_stdout(c"[init] Hello!\n\n");
+    write_to_stdout("[init] Hello!\n\n".as_bytes());
 
     let shell_path = c"/shell";
     let shell_argv = [shell_path.as_ptr(), c"".as_ptr()];
     let shell_pid = spawn(shell_path, &shell_argv);
 
-    let mut buf = [0u8; 100];
-    let msg = c"[init] spawned shell with pid ";
-    let msg_len = msg.to_bytes().len();
-    buf[..msg_len].copy_from_slice(msg.to_bytes());
-    let len = convert_to_string(shell_pid as _, 10, &mut buf[msg_len..]);
-    buf[msg_len + len] = b'\n';
-    write_to_stdout(unsafe { CStr::from_bytes_with_nul_unchecked(&buf) });
+    write_to_stdout(format!("[init] spawned shell with pid {}\n", shell_pid).as_bytes());
 
-    let heap_size = 0x1000;
-    let heap_start = allocate_heap(heap_size);
-    assert!(get_heap_end_ptr() == unsafe { heap_start.add(heap_size) });
-
-    // use the data in the heap to print the heap start ptr
-    let arr_at_heap = unsafe { core::slice::from_raw_parts_mut(heap_start, heap_size) };
-    // zero out
-    arr_at_heap.fill(0);
-    let msg = c"[init] Got new heap at: 0x";
-    arr_at_heap[..msg.to_bytes().len()].copy_from_slice(msg.to_bytes());
-    // put the heap start ptr as integer
-    let len = convert_to_string(
-        heap_start as _,
-        16,
-        &mut arr_at_heap[msg.to_bytes().len()..],
-    );
-    arr_at_heap[msg.to_bytes().len() + len] = b'\n';
-    // print
-    write_to_stdout(unsafe { CStr::from_bytes_with_nul_unchecked(arr_at_heap) });
     exit(111);
 }
 
 #[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    let mut buf = [0u8; 100];
-    let msg = c"[init] panicked!, line: ";
-    buf[..msg.to_bytes().len()].copy_from_slice(msg.to_bytes());
-    let line = _info.location().unwrap().line();
-    let len = convert_to_string(line as _, 10, &mut buf[msg.to_bytes().len()..]);
-    buf[msg.to_bytes().len() + len] = b'\n';
-    write_to_stdout(unsafe { CStr::from_bytes_with_nul_unchecked(&buf) });
-    // write_to_stdout(c"[init] panicked!\n");
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    write_to_stdout(format!("[init] PANIC: {}\n", info).as_bytes());
     exit(0xFF);
 }

--- a/userspace/shell/Cargo.toml
+++ b/userspace/shell/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 kernel_user_link = { path = "../../libraries/kernel_user_link" }
+user_std = { path = "../../libraries/user_std" }


### PR DESCRIPTION
Fixes #14 .

Added a small `user_std` with heap implementation.

The heap implementation used is the exact one we had in the kernel, so now we have removed it from the kernel into `increasing_heap_allocator` library.

This library is as it seems, the core way to get memory is to expand the current heap block, similar to what `sbrk` provide.
Its what we used in the kernel (we map new pages to the heap virtual space).
So it works quite well with our `inc_heap` syscall which is similar to `sbrk`.

So, that's good.

On the performance side, its slower than the default rust allocator. I did small amount of manual tests of vectors allocating and deallocating.
I got the following results:
- `default allocator, I think its using glibc`: `200~220us`
- `mine`: `310~330us`

Of course would be good to do better and more tests, I was trying to play around with benchmark projects (like: https://github.com/daanx/mimalloc-bench/tree/master), but its kinda annoying to setup.
I'm trying to find a project that does bench in Rust, its easier to implement this way. (maybe I should create one).