### PR TITLE
Keyboard driver + File blocking modes

### DIFF
--- a/kernel/src/cpu/interrupts/mod.rs
+++ b/kernel/src/cpu/interrupts/mod.rs
@@ -122,6 +122,6 @@ pub fn create_syscall_interrupt(handler: InterruptHandlerWithAllState) {
     interrupts.idt.user_defined[SPECIAL_SYSCALL_INTERRUPT as usize]
         .set_handler_with_number(handler, SPECIAL_SYSCALL_INTERRUPT + USER_INTERRUPTS_START)
         .set_privilege_level(USER_RING)
-        .set_disable_interrupts(true)
+        .set_disable_interrupts(false)
         .set_stack_index(Some(stack_index::SYSCALL_STACK));
 }

--- a/kernel/src/io/console.rs
+++ b/kernel/src/io/console.rs
@@ -224,7 +224,7 @@ impl LateConsole {
         let mut i = 0;
         let mut keyboard = self.keyboard.lock();
         while i < dst.len() {
-            if let Some(c) = keyboard.pop_from_buffer() {
+            if let Some(c) = keyboard.get_next_char() {
                 if let Some(c) = c.virtual_char {
                     dst[i] = c;
                     i += 1;

--- a/kernel/src/io/keyboard.rs
+++ b/kernel/src/io/keyboard.rs
@@ -418,8 +418,8 @@ impl Keyboard {
         None
     }
 
-    pub fn pop_from_buffer(&mut self) -> Option<Key> {
-        self.input_ring.pop()
+    pub fn get_next_char(&mut self) -> Option<Key> {
+        self.input_ring.pop().or_else(|| self.try_read_char())
     }
 
     #[allow(dead_code)]

--- a/kernel/src/io/mod.rs
+++ b/kernel/src/io/mod.rs
@@ -1,8 +1,7 @@
 use core::{fmt, sync::atomic::AtomicBool};
 
 pub mod console;
-#[allow(dead_code)]
-mod keyboard;
+pub mod keyboard;
 mod uart;
 mod video_memory;
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -115,14 +115,15 @@ pub extern "C" fn kernel_main(multiboot_info: &MultiBoot2Info) -> ! {
     // must be called before interrupts
     gdt::init_kernel_gdt();
     interrupts::init_interrupts();
-    // mount
+    // mount devices map before initializing them
     devices::init_devices_mapping();
     let bios_tables = acpi::get_acpi_tables(multiboot_info).expect("BIOS tables not found");
     println!("BIOS tables: {}", bios_tables);
     apic::init(&bios_tables);
     clock::init(&bios_tables);
-    console::init_late_device();
     unsafe { cpu::set_interrupts() };
+    devices::init_legacy_devices();
+    console::init_late_device();
     devices::prope_pci_devices();
     fs::create_disk_mapping(0).expect("Could not load filesystem");
     finish_boot();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -35,7 +35,7 @@ use cpu::{
 use executable::elf::Elf;
 use increasing_heap_allocator::HeapStats;
 use io::console;
-use kernel_user_link::{FD_STDERR, FD_STDIN, FD_STDOUT};
+use kernel_user_link::{file::BlockingMode, FD_STDERR, FD_STDIN, FD_STDOUT};
 use memory_management::virtual_memory_mapper;
 use multiboot2::MultiBoot2Info;
 use process::scheduler;
@@ -93,7 +93,8 @@ fn load_init_process() {
 
     // add the console to `init` manually, after that processes will either inherit it or open a pipe or something
     // to act as STDIN/STDOUT/STDERR
-    let console = fs::open("/devices/console").expect("Could not find `/devices/console`");
+    let console = fs::open_blocking("/devices/console", BlockingMode::Line)
+        .expect("Could not find `/devices/console`");
     process.attach_file_to_fd(FD_STDIN, console.clone());
     process.attach_file_to_fd(FD_STDOUT, console.clone());
     process.attach_file_to_fd(FD_STDERR, console);

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -225,6 +225,17 @@ impl Process {
         self.open_files.get_mut(&fd)
     }
 
+    pub fn take_file(&mut self, fd: usize) -> Option<fs::File> {
+        self.open_files.remove(&fd)
+    }
+
+    pub fn put_file(&mut self, fd: usize, file: fs::File) {
+        assert!(
+            self.open_files.insert(fd, file).is_none(),
+            "fd already exists"
+        )
+    }
+
     pub fn exit(&mut self, exit_code: u64) {
         self.state = ProcessState::Exited;
         self.exit_code = exit_code;

--- a/libraries/kernel_user_link/src/file.rs
+++ b/libraries/kernel_user_link/src/file.rs
@@ -1,0 +1,37 @@
+/// A blocking flag when dealing with files
+/// When using [`crate::syscalls::SYS_OPEN`], Bit 0 of `flags` argument can be:
+/// 0 - non-blocking
+/// 1 - line buffered
+///
+/// In order to use `Block` mode, you need to issue a special syscall to modify the
+/// properties of the file blocking mode
+/// TODO: add this syscall
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockingMode {
+    None,
+    Line,
+    Block(usize),
+}
+
+impl BlockingMode {
+    pub fn from_flags(flags: u64) -> Self {
+        match flags & 1 {
+            0 => BlockingMode::None,
+            1 => BlockingMode::Line,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Will extract all the information from the flags, will return `None` if the argument
+/// is invalid
+pub fn parse_flags(flags: u64) -> Option<BlockingMode> {
+    let blocking_mode = BlockingMode::from_flags(flags);
+    let flags = flags & !1;
+    // must be 0 at the end
+    if flags == 0 {
+        Some(blocking_mode)
+    } else {
+        None
+    }
+}

--- a/libraries/kernel_user_link/src/lib.rs
+++ b/libraries/kernel_user_link/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod file;
 pub mod syscalls;
 
 pub const FD_STDIN: usize = 0;

--- a/userspace/shell/src/main.rs
+++ b/userspace/shell/src/main.rs
@@ -1,6 +1,9 @@
 #![feature(restricted_std)]
 
-use std::{io::Read, string::String};
+use std::{
+    io::{self, Read},
+    string::String,
+};
 
 fn main() {
     // we are in `init` now
@@ -12,6 +15,15 @@ fn main() {
     println!("[shell] content of `/message.txt`:\n");
     let mut f = std::fs::File::open("/message.txt").unwrap();
     let mut buf = [0; 100];
-    f.read(&mut buf).unwrap();
-    println!("{}", String::from_utf8_lossy(&buf));
+    let res = f.read(&mut buf).unwrap();
+    println!("{}", String::from_utf8_lossy(&buf[..res]));
+
+    buf.fill(0);
+    println!("\n[shell] Input something:");
+    let res = io::stdin().read(&mut buf).unwrap();
+
+    println!(
+        "[shell] stdin: ({res}) {}",
+        String::from_utf8_lossy(&buf[..res])
+    );
 }


### PR DESCRIPTION
Fixes #12 .

We have created `keyboard` device now.

Currently, its not registered in the `devices` map, and instead used directly by the `Console` to achieve `stdin`.

Do note that the keyboard driver is already implemented before this PR, implemented at (3475f48) as part of the `console` then, then it was removed, then its back now. So if you want the implementation of the driver, its at that commit. This is just bringing it back and adding blocking files support and stdin related stuff.
 