### PR TITLE
Kernel interrupt in process context

### DIFF
--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -4,7 +4,7 @@ use crate::{
     memory_management::{
         memory_layout::{
             is_aligned, INTR_STACK_BASE, INTR_STACK_EMPTY_SIZE, INTR_STACK_ENTRY_SIZE,
-            INTR_STACK_SIZE, INTR_STACK_TOTAL_SIZE, KERNEL_STACK_END, PAGE_4K,
+            INTR_STACK_SIZE, INTR_STACK_TOTAL_SIZE, PAGE_4K, PROCESS_KERNEL_STACK_END,
         },
         virtual_memory_mapper::{self, VirtualMemoryMapEntry},
     },
@@ -97,9 +97,9 @@ pub fn init_kernel_gdt() {
             TSS.ist[i] = stack_end_virtual as u64 - 8;
         }
 
-        // ADD entry for the kernel stack, for now no need to set a stack for other rings
-        // since the user stack won't be used
-        unsafe { TSS.rsp[KERNEL_RING as usize] = KERNEL_STACK_END as u64 - 8 };
+        // A kernel stack for this process
+        // this will be used on transitions from user to kernel
+        unsafe { TSS.rsp[KERNEL_RING as usize] = PROCESS_KERNEL_STACK_END as u64 - 8 };
     }
 
     let tss_ptr = (unsafe { &TSS } as *const _) as u64;

--- a/kernel/src/cpu/interrupts/mod.rs
+++ b/kernel/src/cpu/interrupts/mod.rs
@@ -79,41 +79,41 @@ pub fn init_interrupts() {
 
 // All Types of interrupt handlers
 pub trait InterruptHandler {
-    fn set_handler(val: Self) -> u8;
+    fn allocate_and_set_handler(val: Self) -> u8;
 }
 
 impl InterruptHandler for BasicInterruptHandler {
-    fn set_handler(handler: Self) -> u8 {
+    fn allocate_and_set_handler(handler: Self) -> u8 {
         INTERRUPTS.lock().allocate_basic_user_interrupt(handler)
     }
 }
 
 impl InterruptHandler for InterruptHandlerWithAllState {
-    fn set_handler(handler: Self) -> u8 {
+    fn allocate_and_set_handler(handler: Self) -> u8 {
         INTERRUPTS.lock().allocate_user_interrupt_all_saved(handler)
     }
 }
 
 /// Puts the handler in the IDT and returns the interrupt/vector number
 pub(super) fn allocate_user_interrupt<F: InterruptHandler>(handler: F) -> u8 {
-    F::set_handler(handler)
+    F::allocate_and_set_handler(handler)
 }
 
 /// Puts the handler in the IDT and returns the interrupt/vector number
 pub(super) fn allocate_basic_user_interrupt(handler: BasicInterruptHandler) -> u8 {
-    BasicInterruptHandler::set_handler(handler)
+    BasicInterruptHandler::allocate_and_set_handler(handler)
 }
 
-#[allow(dead_code)]
 /// Puts the handler in the IDT and returns the interrupt/vector number
 pub(super) fn allocate_user_interrupt_all_saved(handler: InterruptHandlerWithAllState) -> u8 {
-    InterruptHandlerWithAllState::set_handler(handler)
+    InterruptHandlerWithAllState::allocate_and_set_handler(handler)
 }
 
 pub fn create_scheduler_interrupt(handler: InterruptHandlerWithAllState) {
     let mut interrupts = INTERRUPTS.lock();
     interrupts.idt.user_defined[SPECIAL_SCHEDULER_INTERRUPT as usize]
-        .set_handler_with_number(handler, SPECIAL_SCHEDULER_INTERRUPT + USER_INTERRUPTS_START);
+        .set_handler_with_number(handler, SPECIAL_SCHEDULER_INTERRUPT + USER_INTERRUPTS_START)
+        .set_disable_interrupts(true);
 }
 
 pub fn create_syscall_interrupt(handler: InterruptHandlerWithAllState) {

--- a/kernel/src/cpu/interrupts/mod.rs
+++ b/kernel/src/cpu/interrupts/mod.rs
@@ -13,7 +13,6 @@ static INTERRUPTS: Mutex<Interrupts> = Mutex::new(Interrupts::empty());
 pub(super) mod stack_index {
     pub const FAULTS_STACK: u8 = 0;
     pub const DOUBLE_FAULT_STACK: u8 = 1;
-    pub const SYSCALL_STACK: u8 = 2;
 }
 
 const USER_INTERRUPTS_START: u8 = 0x20;
@@ -122,6 +121,5 @@ pub fn create_syscall_interrupt(handler: InterruptHandlerWithAllState) {
     interrupts.idt.user_defined[SPECIAL_SYSCALL_INTERRUPT as usize]
         .set_handler_with_number(handler, SPECIAL_SYSCALL_INTERRUPT + USER_INTERRUPTS_START)
         .set_privilege_level(USER_RING)
-        .set_disable_interrupts(false)
-        .set_stack_index(Some(stack_index::SYSCALL_STACK));
+        .set_disable_interrupts(false);
 }

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -53,6 +53,7 @@ pub struct Cpu {
     pub context: Option<ProcessContext>,
     // the process id of the current process
     pub process_id: u64,
+    pub scheduling: bool,
 }
 
 impl Cpu {
@@ -64,6 +65,7 @@ impl Cpu {
             n_cli: 0,
             context: None,
             process_id: 0,
+            scheduling: false,
         }
     }
 

--- a/kernel/src/executable/mod.rs
+++ b/kernel/src/executable/mod.rs
@@ -2,8 +2,10 @@ use crate::{cpu, fs, memory_management::virtual_memory_mapper};
 
 pub mod elf;
 
-#[allow(dead_code)]
-pub fn load_elf_to_vm(
+/// # Safety
+/// The `vm` passed must be an exact kernel clone to the current vm
+/// without loading new process specific mappings
+pub unsafe fn load_elf_to_vm(
     elf: &elf::Elf,
     file: &mut fs::File,
     vm: &mut virtual_memory_mapper::VirtualMemoryMapper,
@@ -13,6 +15,8 @@ pub fn load_elf_to_vm(
     let old_vm = virtual_memory_mapper::get_current_vm();
 
     // switch temporaily so we can map the elf
+    // SAFETY: this must be called while the current vm and this new vm must share the same
+    //         kernel regions
     vm.switch_to_this();
 
     let mut min_address = u64::MAX;

--- a/kernel/src/executable/mod.rs
+++ b/kernel/src/executable/mod.rs
@@ -1,4 +1,4 @@
-use crate::{fs, memory_management::virtual_memory_mapper};
+use crate::{cpu, fs, memory_management::virtual_memory_mapper};
 
 pub mod elf;
 
@@ -8,6 +8,8 @@ pub fn load_elf_to_vm(
     file: &mut fs::File,
     vm: &mut virtual_memory_mapper::VirtualMemoryMapper,
 ) -> Result<(usize, usize), fs::FileSystemError> {
+    // we can't be interrupted and load another process vm in the middle of this work
+    cpu::cpu().push_cli();
     let old_vm = virtual_memory_mapper::get_current_vm();
 
     // switch temporaily so we can map the elf
@@ -47,6 +49,8 @@ pub fn load_elf_to_vm(
 
     // switch back to the old vm
     old_vm.switch_to_this();
+    // we can be interrupted again
+    cpu::cpu().pop_cli();
 
     Ok((min_address as usize, max_address as usize))
 }

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 
+use super::virtual_memory_mapper;
+
 extern "C" {
     static begin: usize;
     static end: usize;
@@ -9,8 +11,6 @@ extern "C" {
     static stack_guard_page: usize;
 }
 
-// it starts at 0x10000, which is where the kernel is loaded, and grows down
-pub const KERNEL_STACK_END: usize = 0xFFFF_FFFF_8001_0000;
 // The virtual address of the kernel
 // these are information variables, showing the memory mapping of the kernel
 pub const KERNEL_BASE: usize = 0xFFFF_FFFF_8000_0000;
@@ -44,6 +44,18 @@ pub const KERNEL_EXTRA_MEMORY_BASE: usize = INTR_STACK_BASE + INTR_STACK_TOTAL_S
 // to avoid overflow stuff, we don't use the last page
 pub const KERNEL_LAST_POSSIBLE_ADDR: usize = 0xFFFF_FFFF_FFFF_F000;
 pub const KERNEL_EXTRA_MEMORY_SIZE: usize = KERNEL_LAST_POSSIBLE_ADDR - KERNEL_EXTRA_MEMORY_BASE;
+
+// Kernel Data specific to each process (will be mapped differently for each process)
+pub const KERNEL_PROCESS_VIRTUAL_ADDRESS_START: usize =
+    virtual_memory_mapper::KERNEL_PROCESS_VIRTUAL_ADDRESS_START;
+pub const PROCESS_KERNEL_STACK_GUARD: usize = PAGE_4K;
+// process specific kernel stack, this will be where the process is running while in the kernel
+// the process can be interrupted while in the kernel, so we want to save it into a specific stack
+// space so that other processes don't override it when being run
+pub const PROCESS_KERNEL_STACK_BASE: usize =
+    KERNEL_PROCESS_VIRTUAL_ADDRESS_START + PROCESS_KERNEL_STACK_GUARD;
+pub const PROCESS_KERNEL_STACK_SIZE: usize = PAGE_4K * 8;
+pub const PROCESS_KERNEL_STACK_END: usize = PROCESS_KERNEL_STACK_BASE + PROCESS_KERNEL_STACK_SIZE;
 
 #[allow(dead_code)]
 pub const KB: usize = 0x400;

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -147,8 +147,11 @@ impl Process {
                 | virtual_memory_mapper::flags::PTE_WRITABLE,
         });
 
-        let (_min_addr, max_addr) = load_elf_to_vm(elf, file, &mut vm)?;
-        vm.add_process_specific_mappings();
+        // SAFETY: we know that the vm passed is an exact kernel copy of this vm, so its safe to switch to it
+        // TODO: maybe it would be best to create the new vm inside this function?
+        let (_min_addr, max_addr) = unsafe { load_elf_to_vm(elf, file, &mut vm)? };
+        // SAFETY: we know that the vm is never used after this point until scheduling
+        unsafe { vm.add_process_specific_mappings() };
 
         // set it quite a distance from the elf and align it to 2MB pages (we are not using 2MB virtual memory, so its not related)
         let heap_start = align_up(max_addr + HEAP_OFFSET_FROM_ELF_END, PAGE_2M);
@@ -184,7 +187,9 @@ impl Process {
         })
     }
 
-    pub fn switch_to_this_vm(&mut self) {
+    /// # Safety
+    /// Check [`virtual_memory_mapper::VirtualMemoryMapper::switch_to_this`] for more info
+    pub unsafe fn switch_to_this_vm(&mut self) {
         self.vm.switch_to_this();
     }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -289,6 +289,6 @@ impl Process {
 
 impl Drop for Process {
     fn drop(&mut self) {
-        self.vm.unmap_user_memory();
+        self.vm.unmap_process_memory();
     }
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -135,7 +135,7 @@ impl Process {
         argv: Vec<String>,
     ) -> Result<Self, ProcessError> {
         let id = PROCESS_ID_ALLOCATOR.allocate();
-        let mut vm = virtual_memory_mapper::clone_kernel_vm_as_user();
+        let mut vm = virtual_memory_mapper::clone_current_vm_as_user();
         let stack_end = MAX_USER_VIRTUAL_ADDRESS - PAGE_4K;
         let stack_size = INITIAL_STACK_SIZE_PAGES * PAGE_4K;
         let stack_start = stack_end - stack_size;
@@ -148,6 +148,7 @@ impl Process {
         });
 
         let (_min_addr, max_addr) = load_elf_to_vm(elf, file, &mut vm)?;
+        vm.add_process_specific_mappings();
 
         // set it quite a distance from the elf and align it to 2MB pages (we are not using 2MB virtual memory, so its not related)
         let heap_start = align_up(max_addr + HEAP_OFFSET_FROM_ELF_END, PAGE_2M);


### PR DESCRIPTION
Needed while working on #23 , the reading process would block the other process since it was waiting in the kernel.

Previously we couldn't interrupt a process while it was running in the kernel, turned out easily removing that check in the `yield_current_if_any` doesn't do it :D and introduce a rabbithole of debugging.

### What was happening?

After enabling interrupts in the kernel, the system would crash in a weird way.
After a lot of time debugging, here is what was happening.
```
- Process 0 running in user mode                      (all good)
- Process 0 yields from user mode                     (all good)
- Process 1 running in user mode                      (all good)
- Process 1 goes to kernel mode (syscall for example) (all good)
- Process 1 yields from kernel mode
  (this is not yielding after the syscall like we did
   before this commit, but timer interrupted while in
   kernel mode and yielded, so the state is saved
   of the process while we are in kernel mode)        (all good?)
- Process 0 running in user mode                      (all good)
- Process 0 goes to kernel mode (syscall for example) (BAD) // explained later
- Process 0 goes back to user mode                    (...)
- Process 0 yields from user mode                     (...)
- Process 1 running in kernel mode                    (Catastrophe!)
```
And here we reach the bad stage. But it seems ok? where is the bad part, I don't get what's happening.

What happened is that `Process 1` is still using the kernel resources, even though we thought it yielded, and we saved its whole thread context, but we didn't, the kernel stack used for handling syscalls will be overwritten by `Process 0` on the `BAD` line. 
And then, when the `Process 1` takes back execution in `Catastrophe` line, the whole stack is modified. The state of the process was not saved correctly, because we didn't account for the stack.

### So, how can this be saved?

Easy, just save the stack as well as the other registers.
This took a while to get right (you only see the correct implementation in this commit 🙃)

But here is what's happening in this PR:

- Doesn't change much, but we removed the `SYSCALL_STACK`, since we can  just use the `kernel ring stack` and reduce number of stacks we  need to save as part of the process context. This `kernel ring stack` is where the stack will be used  in case we came from the user mode.
  Without this change, we can still fix the issue.
- Setup a per-process kernel stack, when a process moves to the kernel  by any means, it will use this stack.
  This is saved in the process Kernel region, which is a region in the  virtual memory for kernel memory associated with each process.
  `FFFF_FF80_0000_0000..FFFF_FFFF_8000_0000`
  This will be switched on VM switch, so that's how we can `save` the  stack along with registers.
- BUT, because the stack now is part of the VM, we can't just switch  between VMs easily. So, here are the changes affected by this:
  - `switch_to_kernel` function, since we can't do that inside an    interrupt handler while we are using the kernel stack, we moved it    after the scheduler goes to kernel.
  - When loading the `ELF`, we clone the kernel space of current VM (not the kernel VM),    so that we keep all the process specific stuff (including kernel stack) after we load the elf, we replace those process specific memory with our own new    memory. That's why we call `add_process_specific_mappings` after    loading the elf, after this stage, we should never switch to this VM    unless we use the scheduler.
  - In short, you can't switch VMs if you may be inside an interrupt (using kernel stack) at all unless its a complete kernel space clone (like what we do in the `ELF` loader)
- Another note, is that since now we can be interrupted in the kernel,  there is a gap between when the scheduler loop selects a process and  calling `int FE` to run it, and in this gap, the timer can interrupt  and yield the process while we think we still have it :D
  To fix this, we added `scheduling` variable in the `Cpu` to indicate  that we shouldn't be yielding anything.

  I tried to do it with `push_cli` so that we don't get interrupted, but  for some reason it was still failing sometimes, maybe there is a gap  somewhere and it manages to interrupt and steal the process context,  I think this is a better and more verbose method so will keep it as is  for now.

And yea, that's the end.
Its funny, several times while debugging this, I said `I got it`, but another issue comes up, or I didn't get it at all.

I'm not sure if this is enough when multiprocessing comes into view, but hopefully it won't be a lot of issues :D
