### PR TITLE
Pipes

### DIFF
--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -33,6 +33,9 @@ pub trait Device: Sync + Send + fmt::Debug {
     fn write(&self, _offset: u32, _buf: &[u8]) -> Result<u64, FileSystemError> {
         Err(FileSystemError::WriteNotSupported)
     }
+    fn close(&self) -> Result<(), FileSystemError> {
+        Ok(())
+    }
 }
 
 impl FileSystem for Mutex<Devices> {

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -17,7 +17,7 @@ pub mod pci;
 // TODO: replace with rwlock
 static DEVICES: OnceLock<Arc<Mutex<Devices>>> = OnceLock::new();
 
-const DEVICES_FILESYSTEM_CLUSTER_MAGIC: u32 = 0xdef1ce5;
+pub(crate) const DEVICES_FILESYSTEM_CLUSTER_MAGIC: u32 = 0xdef1ce5;
 
 #[derive(Debug)]
 struct Devices {
@@ -42,13 +42,7 @@ impl FileSystem for Mutex<Devices> {
                 .devices
                 .iter()
                 .map(|(name, device)| {
-                    INode::new_device(
-                        name.clone(),
-                        FileAttributes::EMPTY,
-                        DEVICES_FILESYSTEM_CLUSTER_MAGIC,
-                        0,
-                        Some(device.clone()),
-                    )
+                    INode::new_device(name.clone(), FileAttributes::EMPTY, Some(device.clone()))
                 })
                 .collect())
         } else {
@@ -59,27 +53,6 @@ impl FileSystem for Mutex<Devices> {
     fn read_dir(&self, inode: &INode) -> Result<Vec<INode>, FileSystemError> {
         assert_eq!(inode.start_cluster(), DEVICES_FILESYSTEM_CLUSTER_MAGIC);
         self.open_dir(inode.name())
-    }
-
-    fn read_file(
-        &self,
-        inode: &INode,
-        position: u32,
-        buf: &mut [u8],
-    ) -> Result<u64, FileSystemError> {
-        assert_eq!(inode.start_cluster(), DEVICES_FILESYSTEM_CLUSTER_MAGIC);
-        inode
-            .device()
-            .ok_or(FileSystemError::FileNotFound)?
-            .read(position, buf)
-    }
-
-    fn write_file(&self, inode: &INode, position: u32, buf: &[u8]) -> Result<u64, FileSystemError> {
-        assert_eq!(inode.start_cluster(), DEVICES_FILESYSTEM_CLUSTER_MAGIC);
-        inode
-            .device()
-            .ok_or(FileSystemError::FileNotFound)?
-            .write(position, buf)
     }
 }
 

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -13,6 +13,7 @@ use self::pci::{PciDeviceConfig, PciDevicePropeIterator};
 pub mod clock;
 pub mod ide;
 pub mod pci;
+pub mod pipe;
 
 // TODO: replace with rwlock
 static DEVICES: OnceLock<Arc<Mutex<Devices>>> = OnceLock::new();

--- a/kernel/src/devices/pipe.rs
+++ b/kernel/src/devices/pipe.rs
@@ -1,0 +1,61 @@
+use alloc::{collections::VecDeque, string::String, sync::Arc};
+
+use crate::{
+    fs::{self, FileAttributes, FileSystemError, INode},
+    sync::spin::mutex::Mutex,
+};
+
+use super::Device;
+
+pub fn create_pipe_pair() -> (fs::File, fs::File) {
+    let pipe = Arc::new(Mutex::new(Pipe {
+        buffer: VecDeque::new(),
+    }));
+
+    let inode = INode::new_device(String::from("pipe"), FileAttributes::EMPTY, Some(pipe));
+    let in_file = fs::inode_to_file(
+        inode,
+        fs::empty_filesystem(),
+        0,
+        kernel_user_link::file::BlockingMode::Block(1),
+    );
+    // TODO: change permissions for the file, one is input and the other is output
+    let out_file = in_file.clone();
+
+    (in_file, out_file)
+}
+
+/// Pipe is a device that allows two processes to communicate with each other.
+#[derive(Debug)]
+pub struct Pipe {
+    /// The buffer of the pipe.
+    buffer: VecDeque<u8>,
+}
+
+impl Device for Mutex<Pipe> {
+    fn name(&self) -> &str {
+        "pipe"
+    }
+
+    fn read(&self, _offset: u32, buf: &mut [u8]) -> Result<u64, FileSystemError> {
+        let mut pipe = self.lock();
+        let mut bytes_read = 0;
+        for byte in buf.iter_mut() {
+            if let Some(b) = pipe.buffer.pop_back() {
+                *byte = b;
+                bytes_read += 1;
+            } else {
+                break;
+            }
+        }
+        Ok(bytes_read as u64)
+    }
+
+    fn write(&self, _offset: u32, buf: &[u8]) -> Result<u64, FileSystemError> {
+        let mut pipe = self.lock();
+        for byte in buf.iter() {
+            pipe.buffer.push_front(*byte);
+        }
+        Ok(buf.len() as u64)
+    }
+}

--- a/kernel/src/devices/pipe.rs
+++ b/kernel/src/devices/pipe.rs
@@ -1,4 +1,5 @@
 use alloc::{collections::VecDeque, string::String, sync::Arc};
+use kernel_user_link::file::BlockingMode;
 
 use crate::{
     fs::{self, FileAttributes, FileSystemError, INode},
@@ -7,38 +8,77 @@ use crate::{
 
 use super::Device;
 
+/// Create a connected pipe pair.
+/// The first returned file is the read side of the pipe.
+/// The second returned file is the write side of the pipe.
 pub fn create_pipe_pair() -> (fs::File, fs::File) {
-    let pipe = Arc::new(Mutex::new(Pipe {
+    let pipe = Arc::new(Mutex::new(InnerPipe {
         buffer: VecDeque::new(),
+        read_side_available: true,
+        write_side_available: true,
     }));
 
-    let inode = INode::new_device(String::from("pipe"), FileAttributes::EMPTY, Some(pipe));
-    let in_file = fs::inode_to_file(
-        inode,
+    let read_device = Arc::new(PipeSide {
+        inner: pipe.clone(),
+        is_read_side: true,
+    });
+    let write_device = Arc::new(PipeSide {
+        inner: pipe.clone(),
+        is_read_side: false,
+    });
+
+    let read_inode = INode::new_device(
+        String::from("read_pipe"),
+        FileAttributes::EMPTY,
+        Some(read_device),
+    );
+    let write_inode = INode::new_device(
+        String::from("write_pipe"),
+        FileAttributes::EMPTY,
+        Some(write_device),
+    );
+    let read_file = fs::inode_to_file(
+        read_inode,
         fs::empty_filesystem(),
         0,
-        kernel_user_link::file::BlockingMode::Block(1),
+        BlockingMode::Block(1),
     );
-    // TODO: change permissions for the file, one is input and the other is output
-    let out_file = in_file.clone();
+    // no blocking for write
+    let write_file = fs::inode_to_file(write_inode, fs::empty_filesystem(), 0, BlockingMode::None);
 
-    (in_file, out_file)
+    (read_file, write_file)
 }
 
 /// Pipe is a device that allows two processes to communicate with each other.
 #[derive(Debug)]
-pub struct Pipe {
+struct InnerPipe {
     /// The buffer of the pipe.
     buffer: VecDeque<u8>,
+    read_side_available: bool,
+    write_side_available: bool,
 }
 
-impl Device for Mutex<Pipe> {
+/// Represent one side of a pipe.
+/// Check [`create_pipe_pair`] for more details.
+#[derive(Debug)]
+pub struct PipeSide {
+    inner: Arc<Mutex<InnerPipe>>,
+    is_read_side: bool,
+}
+
+impl Device for PipeSide {
     fn name(&self) -> &str {
         "pipe"
     }
 
     fn read(&self, _offset: u32, buf: &mut [u8]) -> Result<u64, FileSystemError> {
-        let mut pipe = self.lock();
+        if !self.is_read_side {
+            return Err(FileSystemError::ReadNotSupported);
+        }
+        let mut pipe = self.inner.lock();
+        if !pipe.write_side_available {
+            return Err(FileSystemError::EndOfFile);
+        }
         let mut bytes_read = 0;
         for byte in buf.iter_mut() {
             if let Some(b) = pipe.buffer.pop_back() {
@@ -52,10 +92,26 @@ impl Device for Mutex<Pipe> {
     }
 
     fn write(&self, _offset: u32, buf: &[u8]) -> Result<u64, FileSystemError> {
-        let mut pipe = self.lock();
+        if self.is_read_side {
+            return Err(FileSystemError::WriteNotSupported);
+        }
+        let mut pipe = self.inner.lock();
+        if !pipe.read_side_available {
+            return Err(FileSystemError::EndOfFile);
+        }
         for byte in buf.iter() {
             pipe.buffer.push_front(*byte);
         }
         Ok(buf.len() as u64)
+    }
+
+    fn close(&self) -> Result<(), FileSystemError> {
+        let mut pipe = self.inner.lock();
+        if self.is_read_side {
+            pipe.read_side_available = false;
+        } else {
+            pipe.write_side_available = false;
+        }
+        Ok(())
     }
 }

--- a/kernel/src/devices/pipe.rs
+++ b/kernel/src/devices/pipe.rs
@@ -76,7 +76,7 @@ impl Device for PipeSide {
             return Err(FileSystemError::ReadNotSupported);
         }
         let mut pipe = self.inner.lock();
-        if !pipe.write_side_available {
+        if !pipe.write_side_available && pipe.buffer.is_empty() {
             return Err(FileSystemError::EndOfFile);
         }
         let mut bytes_read = 0;

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -438,6 +438,11 @@ impl File {
                         if char_buf == b'\n' || char_buf == b'\0' {
                             break;
                         }
+                    } else {
+                        // TODO: add IO waiting
+                        for _ in 0..100 {
+                            core::hint::spin_loop();
+                        }
                     }
                 }
                 i as u64
@@ -457,7 +462,10 @@ impl File {
                         break read_byte;
                     }
                     // otherwise we wait
-                    // TODO: add waiting
+                    // TODO: add IO waiting
+                    for _ in 0..100 {
+                        core::hint::spin_loop();
+                    }
                 }
             }
         };
@@ -466,10 +474,10 @@ impl File {
         Ok(count)
     }
 
-    pub fn write(&mut self, _buf: &[u8]) -> Result<u64, FileSystemError> {
+    pub fn write(&mut self, buf: &[u8]) -> Result<u64, FileSystemError> {
         let written = self
             .filesystem
-            .write_file(&self.inode, self.position as u32, _buf)?;
+            .write_file(&self.inode, self.position as u32, buf)?;
         self.position += written;
         Ok(written)
     }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -442,8 +442,23 @@ impl File {
                 }
                 i as u64
             }
-            BlockingMode::Block(_size) => {
-                todo!("BlockingMode::Block")
+            BlockingMode::Block(size) => {
+                // TODO: support block size > 1
+                assert!(size == 1, "Only block size 1 is supported");
+
+                // try to read until we have something
+                loop {
+                    let read_byte =
+                        self.filesystem
+                            .read_file(&self.inode, self.position as u32, buf)?;
+
+                    // only if the result is not 0, we can return
+                    if read_byte != 0 {
+                        break read_byte;
+                    }
+                    // otherwise we wait
+                    // TODO: add waiting
+                }
             }
         };
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -512,4 +512,10 @@ impl File {
     pub fn is_blocking(&self) -> bool {
         self.blocking_mode != BlockingMode::None
     }
+
+    pub fn clone_inherit(&self) -> Self {
+        let mut s = self.clone();
+        s.position = 0;
+        s
+    }
 }

--- a/libraries/kernel_user_link/src/lib.rs
+++ b/libraries/kernel_user_link/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod file;
+pub mod process;
 pub mod syscalls;
 
 pub const FD_STDIN: usize = 0;

--- a/libraries/kernel_user_link/src/process.rs
+++ b/libraries/kernel_user_link/src/process.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct SpawnFileMapping {
+    pub src_fd: u64,
+    pub dst_fd: u64,
+}

--- a/libraries/kernel_user_link/src/process.rs
+++ b/libraries/kernel_user_link/src/process.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct SpawnFileMapping {
     pub src_fd: u64,

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -6,7 +6,7 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 6;
+pub const NUM_SYSCALLS: usize = 7;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
@@ -15,6 +15,7 @@ mod numbers {
     pub const SYS_EXIT: u64 = 3;
     pub const SYS_SPAWN: u64 = 4;
     pub const SYS_INC_HEAP: u64 = 5;
+    pub const SYS_CREATE_PIPE: u64 = 6;
 }
 pub use numbers::*;
 

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -218,6 +218,8 @@ pub enum SyscallError {
     CouldNotLoadElf = 6,
     CouldNotAllocateProcess = 7,
     HeapRangesExceeded = 8,
+    EndOfFile = 9,
+    FileNotFound = 10,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -300,6 +302,8 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::CouldNotLoadElf => 6 << 56,
                 SyscallError::CouldNotAllocateProcess => 7 << 56,
                 SyscallError::HeapRangesExceeded => 8 << 56,
+                SyscallError::EndOfFile => 9 << 56,
+                SyscallError::FileNotFound => 10 << 56,
             };
 
             err_upper | (1 << 63)
@@ -345,6 +349,8 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             6 => SyscallError::CouldNotLoadElf,
             7 => SyscallError::CouldNotAllocateProcess,
             8 => SyscallError::HeapRangesExceeded,
+            9 => SyscallError::EndOfFile,
+            10 => SyscallError::FileNotFound,
             _ => invalid_error_code(()),
         };
         SyscallResult::Err(err)

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -188,6 +188,7 @@ pub enum SyscallArgError {
     InvalidUserPointer = 2,
     NotValidUtf8 = 3,
     InvalidHeapIncrement = 4,
+    DuplicateFileMappings = 5,
 }
 
 impl SyscallArgError {
@@ -198,6 +199,7 @@ impl SyscallArgError {
             2 => Ok(Some(SyscallArgError::InvalidUserPointer)),
             3 => Ok(Some(SyscallArgError::NotValidUtf8)),
             4 => Ok(Some(SyscallArgError::InvalidHeapIncrement)),
+            5 => Ok(Some(SyscallArgError::DuplicateFileMappings)),
             _ => Err(()),
         }
     }

--- a/libraries/kernel_user_link/src/syscalls/types_conversions.rs
+++ b/libraries/kernel_user_link/src/syscalls/types_conversions.rs
@@ -24,5 +24,7 @@ impl_convert_for_args![
     u8,
     usize,
     *const u8,
-    *mut u8
+    *mut u8,
+    *const u64,
+    *mut u64
 ];

--- a/libraries/user_std/src/io.rs
+++ b/libraries/user_std/src/io.rs
@@ -2,6 +2,7 @@ use core::ffi::CStr;
 
 use kernel_user_link::call_syscall;
 use kernel_user_link::syscalls::SyscallError;
+use kernel_user_link::syscalls::SYS_CREATE_PIPE;
 use kernel_user_link::syscalls::SYS_OPEN;
 use kernel_user_link::syscalls::SYS_READ;
 use kernel_user_link::syscalls::SYS_WRITE;
@@ -53,4 +54,21 @@ pub unsafe fn syscall_open(
             flags as u64          // flags
         )
     }
+}
+
+/// # Safety
+/// This function creates a pipe and return the descriptors.
+/// Callers must ensure to use the descriptors correctly.
+pub unsafe fn syscall_create_pipe() -> Result<(usize, usize), SyscallError> {
+    let mut in_fd: u64 = 0;
+    let mut out_fd: u64 = 0;
+    unsafe {
+        call_syscall!(
+            SYS_CREATE_PIPE,
+            &mut in_fd as *mut u64 as u64,  // in_fd
+            &mut out_fd as *mut u64 as u64  // out_fd
+        )?
+    };
+
+    Ok((in_fd as usize, out_fd as usize))
 }

--- a/libraries/user_std/src/process.rs
+++ b/libraries/user_std/src/process.rs
@@ -1,8 +1,8 @@
 use core::ffi::{c_char, CStr};
 
+pub use kernel_user_link::process::SpawnFileMapping;
 use kernel_user_link::{
     call_syscall,
-    process::SpawnFileMapping,
     syscalls::{SyscallError, SYS_EXIT, SYS_SPAWN},
 };
 

--- a/libraries/user_std/src/process.rs
+++ b/libraries/user_std/src/process.rs
@@ -2,6 +2,7 @@ use core::ffi::{c_char, CStr};
 
 use kernel_user_link::{
     call_syscall,
+    process::SpawnFileMapping,
     syscalls::{SyscallError, SYS_EXIT, SYS_SPAWN},
 };
 
@@ -21,12 +22,21 @@ pub unsafe fn exit(code: u64) -> ! {
 /// # Safety
 /// path must be a valid C string.
 /// argv must be a valid C string array. ending with a null pointer.
-pub unsafe fn spawn(path: &CStr, argv: &[*const c_char]) -> Result<u64, SyscallError> {
+/// File mappings must be valid and present file mappings.
+/// The fds used in the file mappings must never be used again by the caller, as the ownership is
+/// transferred to the child process.
+pub unsafe fn spawn(
+    path: &CStr,
+    argv: &[*const c_char],
+    file_mappings: &[SpawnFileMapping],
+) -> Result<u64, SyscallError> {
     unsafe {
         call_syscall!(
             SYS_SPAWN,
-            path.as_ptr() as u64, // path
-            argv.as_ptr() as u64, // argv
+            path.as_ptr() as u64,          // path
+            argv.as_ptr() as u64,          // argv
+            file_mappings.as_ptr() as u64, // file_mappings
+            file_mappings.len() as u64     // file_mappings_len
         )
     }
 }

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -1,10 +1,30 @@
 #![feature(restricted_std)]
 
+use std::{
+    io::{Read, Write},
+    process::Stdio,
+};
+
 fn main() {
     // we are in `init` now
     println!("[init] Hello!\n\n");
 
-    let result = std::process::Command::new("/shell").spawn().unwrap();
-
+    let result = std::process::Command::new("/shell")
+        .stdout(Stdio::piped())
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
     println!("[init] spawned shell with pid {}\n", result.id());
+
+    result
+        .stdin
+        .unwrap()
+        .write_all(b"echo Hello from init!")
+        .unwrap();
+
+    let mut stdout = Vec::new();
+    result.stdout.unwrap().read_to_end(&mut stdout).unwrap();
+
+    let output = String::from_utf8(stdout).unwrap();
+    println!("[init] shell output: {}", output);
 }


### PR DESCRIPTION
Partial fix for #13 

Added Anonymous pipes

can be called with `let (read_fd, write_fd) = syscall_create_pipe()?;`

This is what we can do after this PR (piping stdio) easily between processes:
https://github.com/Amjad50/OS/blob/cfc9e590105aee92e166c19e5c79626da62dea37/userspace/init/src/main.rs#L8-L30