### PR TITLE
Reading directories from user mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "amjad_os_kernel_user_link"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "amjad_os_user_std"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "amjad_os_kernel_user_link",
  "compiler_builtins",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -29,7 +29,7 @@ workspace = false
 dependencies = ["build_member"]
 condition= {files_modified = {input=["${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
 command = "cp"
-args = ["-r", "${OUT_DIR}/echo", "${OUT_DIR}/cat", "${FILESYSTEM_PATH}/"]
+args = ["-r", "${OUT_DIR}/echo", "${OUT_DIR}/cat", "${OUT_DIR}/ls", "${FILESYSTEM_PATH}/"]
 
 [tasks.filesystem]
 workspace = false

--- a/kernel/src/devices/pipe.rs
+++ b/kernel/src/devices/pipe.rs
@@ -43,13 +43,21 @@ pub fn create_pipe_pair() -> (fs::File, fs::File) {
     );
     let read_file = fs::File::from_inode(
         read_inode,
+        String::from("read_pipe"),
         fs::empty_filesystem(),
         0,
         BlockingMode::Block(1),
-    );
+    )
+    .expect("This is a file, shouldn't fail");
     // no blocking for write
-    let write_file =
-        fs::File::from_inode(write_inode, fs::empty_filesystem(), 0, BlockingMode::None);
+    let write_file = fs::File::from_inode(
+        write_inode,
+        String::from("write_pipe"),
+        fs::empty_filesystem(),
+        0,
+        BlockingMode::None,
+    )
+    .expect("This is a file, shouldn't fail");
 
     (read_file, write_file)
 }

--- a/kernel/src/executable/elf.rs
+++ b/kernel/src/executable/elf.rs
@@ -296,7 +296,7 @@ impl ElfProgram {
                 return Err(ElfLoadError::InvalidElfOrNotSupported);
             }
             let mut header_bytes = [0u8; mem::size_of::<ElfProgram64>()];
-            if file.read_file(&mut header_bytes)? != header_bytes.len() as u64 {
+            if file.read(&mut header_bytes)? != header_bytes.len() as u64 {
                 return Err(ElfLoadError::UnexpectedEndOfFile);
             }
             let program = unsafe { &*(header_bytes.as_ptr() as *const ElfProgram64) };
@@ -306,7 +306,7 @@ impl ElfProgram {
                 return Err(ElfLoadError::InvalidElfOrNotSupported);
             }
             let mut header_bytes = [0u8; mem::size_of::<ElfProgram32>()];
-            if file.read_file(&mut header_bytes)? != header_bytes.len() as u64 {
+            if file.read(&mut header_bytes)? != header_bytes.len() as u64 {
                 return Err(ElfLoadError::UnexpectedEndOfFile);
             }
             let program = unsafe { &*(header_bytes.as_ptr() as *const ElfProgram32) };
@@ -398,7 +398,7 @@ impl Elf {
     pub fn load(file: &mut fs::File) -> Result<Self, ElfLoadError> {
         // take the largest
         let mut header = [0u8; mem::size_of::<ElfHeader>()];
-        if file.read_file(&mut header)? != header.len() as u64 {
+        if file.read(&mut header)? != header.len() as u64 {
             return Err(ElfLoadError::UnexpectedEndOfFile);
         }
         let header = unsafe { &*(header.as_ptr() as *const ElfHeader) };

--- a/kernel/src/executable/elf.rs
+++ b/kernel/src/executable/elf.rs
@@ -296,7 +296,7 @@ impl ElfProgram {
                 return Err(ElfLoadError::InvalidElfOrNotSupported);
             }
             let mut header_bytes = [0u8; mem::size_of::<ElfProgram64>()];
-            if file.read(&mut header_bytes)? != header_bytes.len() as u64 {
+            if file.read_file(&mut header_bytes)? != header_bytes.len() as u64 {
                 return Err(ElfLoadError::UnexpectedEndOfFile);
             }
             let program = unsafe { &*(header_bytes.as_ptr() as *const ElfProgram64) };
@@ -306,7 +306,7 @@ impl ElfProgram {
                 return Err(ElfLoadError::InvalidElfOrNotSupported);
             }
             let mut header_bytes = [0u8; mem::size_of::<ElfProgram32>()];
-            if file.read(&mut header_bytes)? != header_bytes.len() as u64 {
+            if file.read_file(&mut header_bytes)? != header_bytes.len() as u64 {
                 return Err(ElfLoadError::UnexpectedEndOfFile);
             }
             let program = unsafe { &*(header_bytes.as_ptr() as *const ElfProgram32) };
@@ -398,7 +398,7 @@ impl Elf {
     pub fn load(file: &mut fs::File) -> Result<Self, ElfLoadError> {
         // take the largest
         let mut header = [0u8; mem::size_of::<ElfHeader>()];
-        if file.read(&mut header)? != header.len() as u64 {
+        if file.read_file(&mut header)? != header.len() as u64 {
             return Err(ElfLoadError::UnexpectedEndOfFile);
         }
         let header = unsafe { &*(header.as_ptr() as *const ElfHeader) };

--- a/kernel/src/executable/mod.rs
+++ b/kernel/src/executable/mod.rs
@@ -47,7 +47,7 @@ pub unsafe fn load_elf_to_vm(
                 unsafe { core::slice::from_raw_parts_mut(ptr, segment.file_size() as usize) };
 
             // read the whole segment
-            assert_eq!(file.read(slice)?, segment.file_size());
+            assert_eq!(file.read_file(slice)?, segment.file_size());
         }
     }
 

--- a/kernel/src/executable/mod.rs
+++ b/kernel/src/executable/mod.rs
@@ -47,7 +47,7 @@ pub unsafe fn load_elf_to_vm(
                 unsafe { core::slice::from_raw_parts_mut(ptr, segment.file_size() as usize) };
 
             // read the whole segment
-            assert_eq!(file.read_file(slice)?, segment.file_size());
+            assert_eq!(file.read(slice)?, segment.file_size());
         }
     }
 

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -806,7 +806,7 @@ impl FatFilesystem {
         let mut cluster = inode.start_cluster as u32;
         let cluster_index = position / self.boot_sector.bytes_per_cluster();
         for _ in 0..cluster_index {
-            cluster = match self.read_fat_entry(cluster as u32) {
+            cluster = match self.read_fat_entry(cluster) {
                 FatEntry::Next(next_cluster) => next_cluster,
                 FatEntry::EndOfChain => return Err(FatError::UnexpectedFatEntry.into()),
                 FatEntry::Bad => return Err(FatError::UnexpectedFatEntry.into()),

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -708,4 +708,37 @@ impl FilesystemNode {
             Self::Directory(dir) => &dir.inode,
         }
     }
+
+    pub fn as_file(&self) -> Result<&File, FileSystemError> {
+        match self {
+            Self::File(file) => Ok(file),
+            Self::Directory(_) => Err(FileSystemError::IsDirectory),
+        }
+    }
+
+    pub fn as_file_mut(&mut self) -> Result<&mut File, FileSystemError> {
+        match self {
+            Self::File(file) => Ok(file),
+            Self::Directory(_) => Err(FileSystemError::IsDirectory),
+        }
+    }
+
+    pub fn as_dir(&self) -> Result<&Directory, FileSystemError> {
+        match self {
+            Self::File(_) => Err(FileSystemError::IsNotDirectory),
+            Self::Directory(dir) => Ok(dir),
+        }
+    }
+}
+
+impl From<File> for FilesystemNode {
+    fn from(file: File) -> Self {
+        Self::File(file)
+    }
+}
+
+impl From<Directory> for FilesystemNode {
+    fn from(dir: Directory) -> Self {
+        Self::Directory(dir)
+    }
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -489,9 +489,7 @@ impl File {
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> Result<u64, FileSystemError> {
-        if self.inode.is_dir() {
-            return Err(FileSystemError::IsDirectory);
-        }
+        assert!(!self.inode.is_dir());
 
         let count = match self.blocking_mode {
             BlockingMode::None => self.filesystem.read_file(&self.inode, self.position, buf)?,
@@ -568,9 +566,7 @@ impl File {
     }
 
     pub fn write(&mut self, buf: &[u8]) -> Result<u64, FileSystemError> {
-        if self.inode.is_dir() {
-            return Err(FileSystemError::IsDirectory);
-        }
+        assert!(!self.inode.is_dir());
 
         let written = self
             .filesystem

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -177,6 +177,17 @@ impl INode {
     pub fn device(&self) -> Option<&Arc<dyn Device>> {
         self.device.as_ref()
     }
+
+    pub fn as_file_stat(&self) -> FileStat {
+        FileStat {
+            size: self.size(),
+            file_type: if self.is_dir() {
+                FileType::Directory
+            } else {
+                FileType::File
+            },
+        }
+    }
 }
 
 impl Drop for INode {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -95,9 +95,9 @@ fn load_init_process() {
     // to act as STDIN/STDOUT/STDERR
     let console = fs::File::open_blocking("/devices/console", BlockingMode::Line)
         .expect("Could not find `/devices/console`");
-    process.attach_file_to_fd(FD_STDIN, console.clone_inherit());
-    process.attach_file_to_fd(FD_STDOUT, console.clone_inherit());
-    process.attach_file_to_fd(FD_STDERR, console);
+    process.attach_fs_node_to_fd(FD_STDIN, console.clone_inherit());
+    process.attach_fs_node_to_fd(FD_STDOUT, console.clone_inherit());
+    process.attach_fs_node_to_fd(FD_STDERR, console);
 
     println!("Added `init` process pid={}", process.id());
     scheduler::push_process(process);

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -179,7 +179,7 @@ fn sys_write(all_state: &mut InterruptAllSavedState) -> SyscallResult {
             .get_file(file_index)
             .ok_or(SyscallError::InvalidFileIndex)?;
 
-        file.write(buf).map_err(|e| e.into())
+        file.write_file(buf).map_err(|e| e.into())
     })?;
     SyscallResult::Ok(bytes_written)
 }
@@ -216,13 +216,13 @@ fn sys_read(all_state: &mut InterruptAllSavedState) -> SyscallResult {
                 .ok_or(SyscallError::InvalidFileIndex)?;
             Ok((0, Some(file)))
         } else {
-            let bytes_read = file.read(buf)?;
+            let bytes_read = file.read_file(buf)?;
             Ok::<_, SyscallError>((bytes_read, None))
         }
     })?;
 
     let bytes_read = if let Some(mut file) = file {
-        let bytes_read = file.read(buf)?;
+        let bytes_read = file.read_file(buf)?;
         // put file back
         with_current_process(|process| process.put_file(file_index, file));
         bytes_read

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -179,7 +179,7 @@ fn sys_write(all_state: &mut InterruptAllSavedState) -> SyscallResult {
             .get_file(file_index)
             .ok_or(SyscallError::InvalidFileIndex)?;
 
-        file.write_file(buf).map_err(|e| e.into())
+        file.write(buf).map_err(|e| e.into())
     })?;
     SyscallResult::Ok(bytes_written)
 }
@@ -216,13 +216,13 @@ fn sys_read(all_state: &mut InterruptAllSavedState) -> SyscallResult {
                 .ok_or(SyscallError::InvalidFileIndex)?;
             Ok((0, Some(file)))
         } else {
-            let bytes_read = file.read_file(buf)?;
+            let bytes_read = file.read(buf)?;
             Ok::<_, SyscallError>((bytes_read, None))
         }
     })?;
 
     let bytes_read = if let Some(mut file) = file {
-        let bytes_read = file.read_file(buf)?;
+        let bytes_read = file.read(buf)?;
         // put file back
         with_current_process(|process| process.put_file(file_index, file));
         bytes_read

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amjad_os_kernel_user_link"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/src/file.rs
+++ b/libraries/kernel_user_link/src/file.rs
@@ -76,14 +76,14 @@ pub struct FileStat {
     pub file_type: FileType,
 }
 
-pub const DIR_ENTRY_MAX_NAME_LEN: usize = 255;
+pub const MAX_FILENAME_LEN: usize = 255;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DirFilename([u8; DIR_ENTRY_MAX_NAME_LEN + 1]);
+pub struct DirFilename([u8; MAX_FILENAME_LEN + 1]);
 
 impl Default for DirFilename {
     fn default() -> Self {
-        Self([0; DIR_ENTRY_MAX_NAME_LEN + 1])
+        Self([0; MAX_FILENAME_LEN + 1])
     }
 }
 
@@ -95,9 +95,9 @@ impl DirFilename {
 
 impl From<&str> for DirFilename {
     fn from(s: &str) -> Self {
-        let mut name = [0; DIR_ENTRY_MAX_NAME_LEN + 1];
+        let mut name = [0; MAX_FILENAME_LEN + 1];
         let bytes = s.as_bytes();
-        assert!(bytes.len() < DIR_ENTRY_MAX_NAME_LEN);
+        assert!(bytes.len() < MAX_FILENAME_LEN);
         name[..bytes.len()].copy_from_slice(bytes);
         Self(name)
     }

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -6,7 +6,7 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 11;
+pub const NUM_SYSCALLS: usize = 13;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
@@ -20,6 +20,8 @@ mod numbers {
     pub const SYS_CREATE_PIPE: u64 = 8;
     pub const SYS_WAIT_PID: u64 = 9;
     pub const SYS_STAT: u64 = 10;
+    pub const SYS_OPEN_DIR: u64 = 11;
+    pub const SYS_READ_DIR: u64 = 12;
 }
 pub use numbers::*;
 
@@ -226,6 +228,8 @@ pub enum SyscallError {
     FileNotFound = 10,
     PidNotFound = 11,
     ProcessStillRunning = 12,
+    IsNotDirectory = 13,
+    IsDirectory = 14,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -312,6 +316,8 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::FileNotFound => 10 << 56,
                 SyscallError::PidNotFound => 11 << 56,
                 SyscallError::ProcessStillRunning => 12 << 56,
+                SyscallError::IsNotDirectory => 13 << 56,
+                SyscallError::IsDirectory => 14 << 56,
             };
 
             err_upper | (1 << 63)
@@ -361,6 +367,8 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             10 => SyscallError::FileNotFound,
             11 => SyscallError::PidNotFound,
             12 => SyscallError::ProcessStillRunning,
+            13 => SyscallError::IsNotDirectory,
+            14 => SyscallError::IsDirectory,
             _ => invalid_error_code(()),
         };
         SyscallResult::Err(err)

--- a/libraries/user_std/Cargo.toml
+++ b/libraries/user_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amjad_os_user_std"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]
@@ -14,7 +14,7 @@ categories = ["os"]
 
 [dependencies]
 increasing_heap_allocator = { version="0.1.2", path = "../increasing_heap_allocator" }
-kernel_user_link = { version="0.1.2", path = "../kernel_user_link", package = "amjad_os_kernel_user_link" }
+kernel_user_link = { version="0.1.3", path = "../kernel_user_link", package = "amjad_os_kernel_user_link" }
 
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }

--- a/libraries/user_std/src/io.rs
+++ b/libraries/user_std/src/io.rs
@@ -5,7 +5,7 @@ pub use kernel_user_link::file::DirEntry;
 pub use kernel_user_link::file::DirFilename;
 pub use kernel_user_link::file::FileStat;
 pub use kernel_user_link::file::FileType;
-pub use kernel_user_link::file::DIR_ENTRY_MAX_NAME_LEN;
+pub use kernel_user_link::file::MAX_FILENAME_LEN;
 pub use kernel_user_link::FD_STDERR;
 pub use kernel_user_link::FD_STDIN;
 pub use kernel_user_link::FD_STDOUT;

--- a/userspace/shell/Cargo.toml
+++ b/userspace/shell/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/echo.rs"
 name = "cat"
 path = "src/cat.rs"
 
+[[bin]]
+name = "ls"
+path = "src/ls.rs"
+
 [dependencies]
 std = { path = "../../extern/rust/library/std", default-features = false }
 panic_abort = { path = "../../extern/rust/library/panic_abort" }

--- a/userspace/shell/src/ls.rs
+++ b/userspace/shell/src/ls.rs
@@ -1,0 +1,74 @@
+#![feature(restricted_std)]
+#![feature(io_error_more)]
+
+use std::process::ExitCode;
+
+/// Ls shell program
+///
+/// Usage: ls [paths...]
+
+// helper function
+// `print_parent`: indent more, this will be true if we are printing the parent directory
+fn ls(path: &str, print_parent: bool) {
+    let indent_space = if print_parent { "  " } else { "" };
+    let mut dir = match std::fs::read_dir(path) {
+        Ok(d) => d,
+        Err(e) => {
+            match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    println!("{indent_space}[!] path not found: {}", path);
+                    return;
+                }
+                std::io::ErrorKind::NotADirectory => {
+                    println!("  {}", path);
+                    return;
+                }
+                _ => {}
+            }
+
+            println!("{indent_space}[!] error: {}", e);
+            return;
+        }
+    };
+
+    if print_parent {
+        println!("  {}:", path);
+    }
+
+    loop {
+        match dir.next() {
+            Some(Ok(entry)) => {
+                let dir_slash = if entry.file_type().unwrap().is_dir() {
+                    "/"
+                } else {
+                    ""
+                };
+                println!(
+                    "  {indent_space}{}{dir_slash}",
+                    entry.file_name().to_string_lossy()
+                );
+            }
+            Some(Err(e)) => {
+                println!("{indent_space}[!] error: {}", e);
+            }
+            None => break,
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let args = std::env::args().collect::<Vec<_>>();
+
+    if args.len() < 2 {
+        println!("Usage: {} [paths...]", args[0]);
+        return ExitCode::FAILURE;
+    }
+
+    let print_parent = args.len() > 2;
+
+    for path in args.iter().skip(1) {
+        ls(path, print_parent);
+    }
+
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
Fixes #20 

Adds the ability to read dirs in user space, changes in general:
- `Process` now holds `fs::FilesystemNode` instead of `fs::File`, syscalls are mostly based on either `file` or `dir` and we will use `as_file` and `as_dir` to abort quickly if the handle is not what we expect.
- Other (maybe not the focus here) improvements to pointer related functions in the syscall file, like `sys_arg_to_byte_slice -> sys_arg_to_slice`, `check_ptr`, etc...
- added syscalls `open_dir` and `read_dir` to open a file descriptor to a directory and to read from it. This fd can be closed with `close` syscall. But of course file operations won't work with this and vise versa, file fds can't read directory from them. (At least for now, not sure if this can be useful feature)