### PR TITLE
Cwd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "amjad_os_kernel_user_link"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "amjad_os_user_std"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "amjad_os_kernel_user_link",
  "compiler_builtins",

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use crate::{
-    fs::{self, FileAttributes, FileSystem, FileSystemError, INode},
+    fs::{self, path::Path, FileAttributes, FileSystem, FileSystemError, INode},
     io,
     sync::{once::OnceLock, spin::mutex::Mutex},
 };
@@ -53,8 +53,8 @@ impl FileSystem for Mutex<Devices> {
         ))
     }
 
-    fn open_dir(&self, path: &str) -> Result<Vec<INode>, FileSystemError> {
-        if path == "/" {
+    fn open_dir(&self, path: &Path) -> Result<Vec<INode>, FileSystemError> {
+        if path.is_root() {
             Ok(self
                 .lock()
                 .devices
@@ -73,7 +73,7 @@ impl FileSystem for Mutex<Devices> {
             return Err(FileSystemError::IsNotDirectory);
         }
         assert_eq!(inode.start_cluster(), DEVICES_FILESYSTEM_CLUSTER_MAGIC);
-        self.open_dir(inode.name())
+        self.open_dir(Path::new(inode.name()))
     }
 }
 

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -19,6 +19,7 @@ pub mod pipe;
 static DEVICES: OnceLock<Arc<Mutex<Devices>>> = OnceLock::new();
 
 pub(crate) const DEVICES_FILESYSTEM_CLUSTER_MAGIC: u64 = 0xdef1ce5;
+pub(crate) const DEVICES_FILESYSTEM_ROOT_INODE_MAGIC: u64 = 0xdef1ce55007;
 
 #[derive(Debug)]
 struct Devices {
@@ -48,13 +49,13 @@ impl FileSystem for Mutex<Devices> {
         Ok(INode::new_file(
             String::from("/"),
             FileAttributes::DIRECTORY,
-            DEVICES_FILESYSTEM_CLUSTER_MAGIC,
+            DEVICES_FILESYSTEM_ROOT_INODE_MAGIC,
             0,
         ))
     }
 
     fn open_dir(&self, path: &Path) -> Result<Vec<INode>, FileSystemError> {
-        if path.is_root() {
+        if path.is_root() || path.is_empty() {
             Ok(self
                 .lock()
                 .devices
@@ -72,7 +73,7 @@ impl FileSystem for Mutex<Devices> {
         if !inode.is_dir() {
             return Err(FileSystemError::IsNotDirectory);
         }
-        assert_eq!(inode.start_cluster(), DEVICES_FILESYSTEM_CLUSTER_MAGIC);
+        assert_eq!(inode.start_cluster(), DEVICES_FILESYSTEM_ROOT_INODE_MAGIC);
         self.open_dir(Path::new(inode.name()))
     }
 }

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -15,7 +15,7 @@ use crate::{
     sync::spin::mutex::Mutex,
 };
 
-use super::{FileAttributes, FileSystem, FileSystemError, INode};
+use super::{path::Path, FileAttributes, FileSystem, FileSystemError, INode};
 
 const DIRECTORY_ENTRY_SIZE: u32 = 32;
 
@@ -869,8 +869,9 @@ impl FileSystem for Mutex<FatFilesystem> {
         self.lock().read_file(inode, position as u32, buf)
     }
 
-    fn open_dir(&self, path: &str) -> Result<Vec<INode>, FileSystemError> {
-        Ok(self.lock().open_dir(path)?.collect())
+    fn open_dir(&self, path: &Path) -> Result<Vec<INode>, FileSystemError> {
+        // TODO: handle `Path` here
+        Ok(self.lock().open_dir(path.as_str())?.collect())
     }
 
     fn read_dir(&self, inode: &INode) -> Result<Vec<INode>, FileSystemError> {

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -15,7 +15,10 @@ use crate::{
     sync::spin::mutex::Mutex,
 };
 
-use super::{path::Path, FileAttributes, FileSystem, FileSystemError, INode};
+use super::{
+    path::{Component, Path},
+    FileAttributes, FileSystem, FileSystemError, INode,
+};
 
 const DIRECTORY_ENTRY_SIZE: u32 = 32;
 
@@ -732,20 +735,20 @@ impl FatFilesystem {
         }
     }
 
-    pub fn open_dir(&self, path: &str) -> Result<DirectoryIterator, FileSystemError> {
-        if path.is_empty() {
-            return Err(FileSystemError::InvalidPath);
-        }
-        if !path.starts_with('/') {
-            return Err(FileSystemError::InvalidPath);
-        }
+    pub fn open_dir(&self, path: &Path) -> Result<DirectoryIterator, FileSystemError> {
         let root = self.open_root_dir()?;
-        if path == "/" {
+        if path.is_root() || path.is_empty() {
             return DirectoryIterator::new(self, root);
         }
 
         let mut dir = root;
-        'component_loop: for component in path[1..].split('/') {
+        'component_loop: for component in path.components() {
+            let component = match component {
+                Component::RootDir | Component::CurDir => {
+                    continue;
+                }
+                keep @ (Component::ParentDir | Component::Normal(_)) => keep.as_str(),
+            };
             if component.is_empty() {
                 continue;
             }
@@ -871,7 +874,7 @@ impl FileSystem for Mutex<FatFilesystem> {
 
     fn open_dir(&self, path: &Path) -> Result<Vec<INode>, FileSystemError> {
         // TODO: handle `Path` here
-        Ok(self.lock().open_dir(path.as_str())?.collect())
+        Ok(self.lock().open_dir(path)?.collect())
     }
 
     fn read_dir(&self, inode: &INode) -> Result<Vec<INode>, FileSystemError> {

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -444,8 +444,7 @@ pub(crate) fn open_inode<P: AsRef<Path>>(
         }
     }
 
-    let root = Path::new("/");
-    for entry in filesystem.open_dir(&root.join(parent))? {
+    for entry in filesystem.open_dir(parent)? {
         if entry.name() == filename {
             // if this is a file, return error if we requst a directory (using "/")
             if !entry.is_dir() && opening_dir {

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -656,6 +656,7 @@ impl Directory {
             return Err(FileSystemError::IsNotDirectory);
         }
 
+        // TODO: read dynamically, not at creation, as we sometimes don't use this (e.g. current_dir in `Process`)
         let dir_entries = filesystem.read_dir(&inode)?;
 
         Ok(Self {
@@ -664,6 +665,10 @@ impl Directory {
             position,
             dir_entries,
         })
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
     pub fn read(&mut self, entries: &mut [DirEntry]) -> Result<usize, FileSystemError> {
@@ -685,6 +690,17 @@ impl Directory {
         }
 
         Ok(i)
+    }
+}
+
+impl Clone for Directory {
+    fn clone(&self) -> Self {
+        Self {
+            inode: self.inode.clone(),
+            path: self.path.clone(),
+            position: 0,
+            dir_entries: self.dir_entries.clone(),
+        }
     }
 }
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -16,6 +16,7 @@ use self::mbr::MbrRaw;
 
 mod fat;
 mod mbr;
+mod path;
 
 static FILESYSTEM_MAPPING: Mutex<FileSystemMapping> = Mutex::new(FileSystemMapping {
     mappings: Vec::new(),

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -443,6 +443,9 @@ pub(crate) fn open_inode<P: AsRef<Path>>(
             Some(Component::ParentDir) => {
                 // ignore
                 // drop next component
+                // FIXME: there is a bug here, `/welcome/../..` will be treated as `/welcome`
+                //       as the first `..` will drop the second `..`
+                //       implement better handling of this and make it global, probably in [`Path`]
                 comp.next_back();
             }
         }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -337,6 +337,7 @@ pub enum FileSystemError {
     FatError(fat::FatError),
     FileNotFound,
     InvalidPath,
+    MustBeAbsolute,
     IsNotDirectory,
     IsDirectory,
     InvalidOffset,
@@ -407,11 +408,14 @@ pub fn create_disk_mapping(hard_disk_index: usize) -> Result<(), FileSystemError
 }
 
 /// Open the inode of a path, this include directories and files.
+///
+/// This function must be called with an absolute path. Otherwise it will return [`FileSystemError::MustBeAbsolute`].
 pub(crate) fn open_inode<P: AsRef<Path>>(
     path: P,
 ) -> Result<(Arc<dyn FileSystem>, INode), FileSystemError> {
     if !path.as_ref().is_absolute() {
-        return Err(FileSystemError::InvalidPath);
+        // this is an internal kernel only result, this function must be called with an absolute path
+        return Err(FileSystemError::MustBeAbsolute);
     }
     let (remaining, filesystem) = get_mapping(path.as_ref())?;
 

--- a/kernel/src/fs/path.rs
+++ b/kernel/src/fs/path.rs
@@ -1198,6 +1198,56 @@ impl Path {
             .unwrap_or(false)
     }
 
+    /// Checks if the path is the root directory.
+    ///
+    /// This function compares the path string with "/", the root directory.
+    /// If the path is "/", it returns `true`. For any other path, it returns `false`.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if the path is the root directory ("/").
+    /// * `false` if the path is not the root directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use your_module::Path;
+    ///
+    /// let p = Path::new("/");
+    /// assert_eq!(p.is_root(), true);
+    ///
+    /// let p = Path::new("/some/path");
+    /// assert_eq!(p.is_root(), false);
+    /// ```
+    pub fn is_root(&self) -> bool {
+        self.as_str() == "/"
+    }
+
+    /// Checks if the path is empty.
+    ///
+    /// This function checks if the path string is empty. If the path is an empty string, it returns `true`.
+    /// For any non-empty path, it returns `false`.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if the path is an empty string.
+    /// * `false` if the path is not an empty string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use your_module::Path;
+    ///
+    /// let p = Path::new("");
+    /// assert_eq!(p.is_empty(), true);
+    ///
+    /// let p = Path::new("/some/path");
+    /// assert_eq!(p.is_empty(), false);
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.as_str().is_empty()
+    }
+
     /// Returns the `Path` without its final component, if there is one.
     ///
     /// Returns `None` if the path terminates in a root or prefix.

--- a/kernel/src/fs/path.rs
+++ b/kernel/src/fs/path.rs
@@ -1,0 +1,1612 @@
+// This is taken and heavily modified of `unix_path`
+// which is modified from the standard library.
+// source: https://gitlab.com/SnejUgal/unix_path
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! A library for parsing, manipulating Paths that follow unix style conventions.
+//!
+//! This is similar to how the standard library's [`Path`] works, but may have less features.
+//!
+//! For simplicity, this uses `str` and `String` instead of `OsStr` and `OsString`.
+//! Makes it much easier to work with.
+use core::{
+    borrow::Borrow,
+    cmp, fmt,
+    hash::{Hash, Hasher},
+    iter::{self, FusedIterator},
+    ops::{self, Deref},
+    str::FromStr,
+};
+
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    rc::Rc,
+    string::{String, ToString},
+    sync::Arc,
+};
+
+/// use unix pathes seperator
+pub const SEPARATOR: char = '/';
+
+pub fn is_separator(c: char) -> bool {
+    c == SEPARATOR
+}
+
+fn is_separator_byte(c: u8) -> bool {
+    c == SEPARATOR as u8
+}
+
+// Iterate through `iter` while it matches `prefix`; return `None` if `prefix`
+// is not a prefix of `iter`, otherwise return `Some(iter_after_prefix)` giving
+// `iter` after having exhausted `prefix`.
+fn iter_after<'a, 'b, I, J>(mut iter: I, mut prefix: J) -> Option<I>
+where
+    I: Iterator<Item = Component<'a>> + Clone,
+    J: Iterator<Item = Component<'b>>,
+{
+    loop {
+        let mut iter_next = iter.clone();
+        match (iter_next.next(), prefix.next()) {
+            (Some(ref x), Some(ref y)) if x == y => (),
+            (Some(_), Some(_)) => return None,
+            (Some(_), None) => return Some(iter),
+            (None, None) => return Some(iter),
+            (None, Some(_)) => return None,
+        }
+        iter = iter_next;
+    }
+}
+
+/// Check if the first char is `/`
+fn has_root(path: &str) -> bool {
+    !path.is_empty() && path.as_bytes()[0] == b'/'
+}
+
+/// Component parsing works by a double-ended state machine; the cursors at the
+/// front and back of the path each keep track of what parts of the path have
+/// been consumed so far.
+///
+/// Going front to back, a path is made up of a prefix, a starting
+/// directory component, and a body (of normal components)
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+enum State {
+    Prefix = 0,
+    StartDir = 1, // / or . or nothing
+    Body = 2,     // foo/bar/baz
+    Done = 3,
+}
+
+/// A single component of a path.
+///
+/// A `Component` roughly corresponds to a substring between path separators
+/// (`/`).
+///
+/// This `enum` is created by iterating over [`Components`], which in turn is
+/// created by the [`components`][`Path::components`] method on [`Path`].
+///
+/// # Examples
+///
+/// ```rust
+/// let path = Path::new("/tmp/foo/bar.txt");
+/// let components = path.components().collect::<Vec<_>>();
+/// assert_eq!(&components, &[
+///     Component::RootDir,
+///     Component::Normal("tmp".as_ref()),
+///     Component::Normal("foo".as_ref()),
+///     Component::Normal("bar.txt".as_ref()),
+/// ]);
+/// ```
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Component<'a> {
+    /// The root directory component, appears after any prefix and before anything else.
+    ///
+    /// It represents a separator that designates that a path starts from root.
+    RootDir,
+
+    /// A reference to the current directory, i.e., `.`.
+    CurDir,
+
+    /// A reference to the parent directory, i.e., `..`.
+    ParentDir,
+
+    /// A normal component, e.g., `a` and `b` in `a/b`.
+    ///
+    /// This variant is the most common one, it represents references to files
+    /// or directories.
+    Normal(&'a str),
+}
+
+impl<'a> Component<'a> {
+    /// Extracts the underlying `str`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("./tmp/foo/bar.txt");
+    /// let components: Vec<_> = path.components().map(|comp| comp.as_str()).collect();
+    /// assert_eq!(&components, &[".", "tmp", "foo", "bar.txt"]);
+    /// ```
+    pub fn as_str(self) -> &'a str {
+        match self {
+            Component::RootDir => "/",
+            Component::CurDir => ".",
+            Component::ParentDir => "..",
+            Component::Normal(path) => path,
+        }
+    }
+}
+
+impl AsRef<str> for Component<'_> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<Path> for Component<'_> {
+    fn as_ref(&self) -> &Path {
+        self.as_str().as_ref()
+    }
+}
+
+/// An iterator over the [`Component`]s of a [`Path`].
+///
+/// This `struct` is created by the [`components`] method on [`Path`].
+/// See its documentation for more.
+///
+/// # Examples
+///
+/// ```
+/// let path = Path::new("/tmp/foo/bar.txt");
+///
+/// for component in path.components() {
+///     println!("{:?}", component);
+/// }
+/// ```
+#[derive(Clone)]
+pub struct Components<'a> {
+    // The path left to parse components from
+    path: &'a str,
+
+    // true if path *physically* has a root separator;.
+    has_root: bool,
+
+    // The iterator is double-ended, and these two states keep track of what has
+    // been produced from either end
+    front: State,
+    back: State,
+}
+
+/// An iterator over the [`Component`]s of a [`Path`], as [`str`] slices.
+///
+/// This `struct` is created by the [`iter`] method on [`Path`].
+/// See its documentation for more.
+#[derive(Clone)]
+pub struct Iter<'a> {
+    inner: Components<'a>,
+}
+
+impl fmt::Debug for Components<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct DebugHelper<'a>(&'a Path);
+
+        impl fmt::Debug for DebugHelper<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_list().entries(self.0.components()).finish()
+            }
+        }
+
+        f.debug_tuple("Components")
+            .field(&DebugHelper(self.as_path()))
+            .finish()
+    }
+}
+
+impl<'a> Components<'a> {
+    // Given the iteration so far, how much of the pre-State::Body path is left?
+    #[inline]
+    fn len_before_body(&self) -> usize {
+        let root = if self.front <= State::StartDir && self.has_root {
+            1
+        } else {
+            0
+        };
+        let cur_dir = if self.front <= State::StartDir && self.include_cur_dir() {
+            1
+        } else {
+            0
+        };
+        root + cur_dir
+    }
+
+    // is the iteration complete?
+    #[inline]
+    fn finished(&self) -> bool {
+        self.front == State::Done || self.back == State::Done || self.front > self.back
+    }
+
+    /// Extracts a slice corresponding to the portion of the path remaining for iteration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut components = Path::new("/tmp/foo/bar.txt").components();
+    /// components.next();
+    /// components.next();
+    ///
+    /// assert_eq!(Path::new("foo/bar.txt"), components.as_path());
+    /// ```
+    pub fn as_path(&self) -> &'a Path {
+        let mut comps = self.clone();
+        if comps.front == State::Body {
+            comps.trim_left();
+        }
+        if comps.back == State::Body {
+            comps.trim_right();
+        }
+        Path::new(comps.path)
+    }
+
+    /// Is the *original* path rooted?
+    fn has_root(&self) -> bool {
+        self.has_root
+    }
+
+    /// Should the normalized path include a leading . ?
+    fn include_cur_dir(&self) -> bool {
+        if self.has_root() {
+            return false;
+        }
+        let mut iter = self.path[..].chars();
+        match (iter.next(), iter.next()) {
+            (Some('.'), None) => true,
+            (Some('.'), Some(c)) => is_separator(c),
+            _ => false,
+        }
+    }
+
+    // parse a given byte sequence into the corresponding path component
+    fn parse_single_component<'b>(&self, comp: &'b str) -> Option<Component<'b>> {
+        match comp {
+            "." => None, // . components are normalized away, except at
+            // the beginning of a path, which is treated
+            // separately via `include_cur_dir`
+            ".." => Some(Component::ParentDir),
+            "" => None,
+            _ => Some(Component::Normal(comp)),
+        }
+    }
+
+    // parse a component from the left, saying how many bytes to consume to
+    // remove the component
+    fn parse_next_component(&self) -> (usize, Option<Component<'a>>) {
+        debug_assert!(self.front == State::Body);
+        let (extra, comp) = match self.path.chars().position(is_separator) {
+            None => (0, self.path),
+            Some(i) => (1, &self.path[..i]),
+        };
+        (comp.len() + extra, self.parse_single_component(comp))
+    }
+
+    // parse a component from the right, saying how many bytes to consume to
+    // remove the component
+    fn parse_next_component_back(&self) -> (usize, Option<Component<'a>>) {
+        debug_assert!(self.back == State::Body);
+        let start = self.len_before_body();
+        // FIXME: should be `chars`, but its easier this way
+        let (extra, comp) = match self.path[start..].bytes().rposition(is_separator_byte) {
+            None => (0, &self.path[start..]),
+            Some(i) => (1, &self.path[start + i + 1..]),
+        };
+        (comp.len() + extra, self.parse_single_component(comp))
+    }
+
+    // trim away repeated separators (i.e., empty components) on the left
+    fn trim_left(&mut self) {
+        while !self.path.is_empty() {
+            let (size, comp) = self.parse_next_component();
+            if comp.is_some() {
+                return;
+            } else {
+                self.path = &self.path[size..];
+            }
+        }
+    }
+
+    // trim away repeated separators (i.e., empty components) on the right
+    fn trim_right(&mut self) {
+        while self.path.len() > self.len_before_body() {
+            let (size, comp) = self.parse_next_component_back();
+            if comp.is_some() {
+                return;
+            } else {
+                self.path = &self.path[..self.path.len() - size];
+            }
+        }
+    }
+}
+
+impl AsRef<Path> for Components<'_> {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
+
+impl AsRef<str> for Components<'_> {
+    fn as_ref(&self) -> &str {
+        self.as_path().as_str()
+    }
+}
+
+impl fmt::Debug for Iter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct DebugHelper<'a>(&'a Path);
+
+        impl fmt::Debug for DebugHelper<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_list().entries(self.0.iter()).finish()
+            }
+        }
+
+        f.debug_tuple("Iter")
+            .field(&DebugHelper(self.as_path()))
+            .finish()
+    }
+}
+
+impl<'a> Iter<'a> {
+    /// Extracts a slice corresponding to the portion of the path remaining for iteration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut iter = Path::new("/tmp/foo/bar.txt").iter();
+    /// iter.next();
+    /// iter.next();
+    ///
+    /// assert_eq!(Path::new("foo/bar.txt"), iter.as_path());
+    /// ```
+    pub fn as_path(&self) -> &'a Path {
+        self.inner.as_path()
+    }
+}
+
+impl AsRef<Path> for Iter<'_> {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
+
+impl AsRef<str> for Iter<'_> {
+    fn as_ref(&self) -> &str {
+        self.as_path().as_str()
+    }
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(Component::as_str)
+    }
+}
+
+impl<'a> DoubleEndedIterator for Iter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(Component::as_str)
+    }
+}
+
+impl FusedIterator for Iter<'_> {}
+
+impl<'a> Iterator for Components<'a> {
+    type Item = Component<'a>;
+
+    fn next(&mut self) -> Option<Component<'a>> {
+        while !self.finished() {
+            match self.front {
+                State::Prefix => {
+                    self.front = State::StartDir;
+                }
+                State::StartDir => {
+                    self.front = State::Body;
+                    if self.has_root {
+                        debug_assert!(!self.path.is_empty());
+                        self.path = &self.path[1..];
+                        return Some(Component::RootDir);
+                    } else if self.include_cur_dir() {
+                        debug_assert!(!self.path.is_empty());
+                        self.path = &self.path[1..];
+                        return Some(Component::CurDir);
+                    }
+                }
+                State::Body if !self.path.is_empty() => {
+                    let (size, comp) = self.parse_next_component();
+                    self.path = &self.path[size..];
+                    if comp.is_some() {
+                        return comp;
+                    }
+                }
+                State::Body => {
+                    self.front = State::Done;
+                }
+                State::Done => unreachable!(),
+            }
+        }
+        None
+    }
+}
+
+impl<'a> DoubleEndedIterator for Components<'a> {
+    fn next_back(&mut self) -> Option<Component<'a>> {
+        while !self.finished() {
+            match self.back {
+                State::Body if self.path.len() > self.len_before_body() => {
+                    let (size, comp) = self.parse_next_component_back();
+                    self.path = &self.path[..self.path.len() - size];
+                    if comp.is_some() {
+                        return comp;
+                    }
+                }
+                State::Body => {
+                    self.back = State::StartDir;
+                }
+                State::StartDir => {
+                    self.back = State::Prefix;
+                    if self.has_root {
+                        self.path = &self.path[..self.path.len() - 1];
+                        return Some(Component::RootDir);
+                    } else if self.include_cur_dir() {
+                        self.path = &self.path[..self.path.len() - 1];
+                        return Some(Component::CurDir);
+                    }
+                }
+                State::Prefix => {
+                    self.back = State::Done;
+                    return None;
+                }
+                State::Done => unreachable!(),
+            }
+        }
+        None
+    }
+}
+
+impl FusedIterator for Components<'_> {}
+
+impl<'a> cmp::PartialEq for Components<'a> {
+    fn eq(&self, other: &Components<'a>) -> bool {
+        Iterator::eq(self.clone(), other.clone())
+    }
+}
+
+impl cmp::Eq for Components<'_> {}
+
+impl<'a> cmp::PartialOrd for Components<'a> {
+    fn partial_cmp(&self, other: &Components<'a>) -> Option<cmp::Ordering> {
+        Iterator::partial_cmp(self.clone(), other.clone())
+    }
+}
+
+impl cmp::Ord for Components<'_> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        Iterator::cmp(self.clone(), other.clone())
+    }
+}
+
+/// An iterator over [`Path`] and its ancestors.
+///
+/// This `struct` is created by the [`Path::ancestors`] method on [`Path`].
+/// See its documentation for more.
+///
+/// # Examples
+///
+/// ```
+/// let path = Path::new("/foo/bar");
+///
+/// for ancestor in path.ancestors() {
+///     println!("{:?}", ancestor);
+/// }
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Ancestors<'a> {
+    next: Option<&'a Path>,
+}
+
+impl<'a> Iterator for Ancestors<'a> {
+    type Item = &'a Path;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.next;
+        self.next = next.and_then(Path::parent);
+        next
+    }
+}
+
+impl FusedIterator for Ancestors<'_> {}
+
+/// An owned, mutable path (akin to `String`).
+///
+/// This type provides methods like [`PathBuf::push`] that mutate
+/// the path in place. It also implements `Deref` to [`Path`], meaning that
+/// all methods on [`Path`] slices are available on `PathBuf` values as well.
+///
+/// More details about the overall approach can be found in
+/// the [crate documentation](index.html).
+///
+/// # Examples
+///
+/// You can use [`PathBuf::push`] to build up a [`PathBuf`] from
+/// components:
+///
+/// ```
+/// let mut path = PathBuf::new();
+///
+/// path.push("/");
+/// path.push("feel");
+/// path.push("the");
+/// ```
+///
+/// However, [`PathBuf::push`] is best used for dynamic situations. This is a better way
+/// to do this when you know all of the components ahead of time:
+///
+/// ```
+/// let path: PathBuf = ["/", "feel", "the.force"].iter().collect();
+/// ```
+///
+/// We can still do better than this! Since these are all strings, we can use
+/// [`From::from`]:
+///
+/// ```
+/// let path = PathBuf::from(r"/feel/the.force");
+/// ```
+///
+/// Which method works best depends on what kind of situation you're in.
+#[derive(Clone)]
+pub struct PathBuf {
+    inner: String,
+}
+
+impl PathBuf {
+    /// Allocates an empty [`PathBuf`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = PathBuf::new();
+    /// ```
+    pub fn new() -> PathBuf {
+        PathBuf {
+            inner: String::new(),
+        }
+    }
+
+    /// Creates a new [`PathBuf`] with a given capacity used to create the
+    /// internal [`String`]. See [`String::with_capacity`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut path = PathBuf::with_capacity(10);
+    /// let capacity = path.capacity();
+    ///
+    /// // This push is done without reallocating
+    /// path.push("/");
+    ///
+    /// assert_eq!(capacity, path.capacity());
+    /// ```
+    pub fn with_capacity(capacity: usize) -> PathBuf {
+        PathBuf {
+            inner: String::with_capacity(capacity),
+        }
+    }
+
+    /// Coerces to a [`Path`] slice.
+    ///
+    /// [`Path`]: struct.Path.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let p = PathBuf::from("/test");
+    /// assert_eq!(Path::new("/test"), p.as_path());
+    /// ```
+    pub fn as_path(&self) -> &Path {
+        self
+    }
+
+    /// Extends `self` with `path`.
+    ///
+    /// If `path` is absolute, it replaces the current path.
+    ///
+    /// # Examples
+    ///
+    /// Pushing a relative path extends the existing path:
+    ///
+    /// ```
+    /// let mut path = PathBuf::from("/tmp");
+    /// path.push("file.bk");
+    /// assert_eq!(path, PathBuf::from("/tmp/file.bk"));
+    /// ```
+    ///
+    /// Pushing an absolute path replaces the existing path:
+    ///
+    /// ```
+    /// let mut path = PathBuf::from("/tmp");
+    /// path.push("/etc");
+    /// assert_eq!(path, PathBuf::from("/etc"));
+    /// ```
+    pub fn push<P: AsRef<Path>>(&mut self, path: P) {
+        self._push(path.as_ref())
+    }
+
+    fn _push(&mut self, path: &Path) {
+        // in general, a separator is needed if the rightmost byte is not a separator
+        let need_sep = self
+            .as_str()
+            .chars()
+            .last()
+            .map(|c| !is_separator(c))
+            .unwrap_or(false);
+
+        // absolute `path` replaces `self`
+        if path.is_absolute() || path.has_root() {
+            self.inner.clear();
+        } else if need_sep {
+            self.inner.push(SEPARATOR);
+        }
+
+        self.inner.push_str(path.as_str());
+    }
+
+    /// Truncates `self` to [`self.parent`].
+    ///
+    /// Returns `false` and does nothing if [`self.parent`] is `None`.
+    /// Otherwise, returns `true`.
+    ///
+    /// [`self.parent`]: struct.PathBuf.html#method.parent
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut p = PathBuf::from("/test/test.rs");
+    ///
+    /// p.pop();
+    /// assert_eq!(Path::new("/test"), p);
+    /// p.pop();
+    /// assert_eq!(Path::new("/"), p);
+    /// ```
+    pub fn pop(&mut self) -> bool {
+        match self.parent().map(|p| p.as_str().len()) {
+            Some(len) => {
+                self.inner.truncate(len);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Updates [`self.file_name`] to `file_name`.
+    ///
+    /// If [`self.file_name`] was `None`, this is equivalent to pushing
+    /// `file_name`.
+    ///
+    /// Otherwise it is equivalent to calling [`pop`] and then pushing
+    /// `file_name`. The new path will be a sibling of the original path.
+    /// (That is, it will have the same parent.)
+    ///
+    /// [`self.file_name`]: PathBuf
+    /// [`pop`]: PathBuf::pop
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut buf = PathBuf::from("/");
+    /// assert!(buf.file_name() == None);
+    /// buf.set_file_name("bar");
+    /// assert!(buf == PathBuf::from("/bar"));
+    /// assert!(buf.file_name().is_some());
+    /// buf.set_file_name("baz.txt");
+    /// assert!(buf == PathBuf::from("/baz.txt"));
+    /// ```
+    pub fn set_file_name<S: AsRef<str>>(&mut self, file_name: S) {
+        self._set_file_name(file_name.as_ref())
+    }
+
+    fn _set_file_name(&mut self, file_name: &str) {
+        if self.file_name().is_some() {
+            let popped = self.pop();
+            debug_assert!(popped);
+        }
+        self.push(file_name);
+    }
+
+    /// Consumes the `PathBuf`, yielding its internal `String` storage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let p = PathBuf::from("/the/head");
+    /// let bytes = p.into_string();
+    /// ```
+    pub fn into_string(self) -> String {
+        self.inner
+    }
+
+    /// Converts this `PathBuf` into a boxed [`Path`].
+    ///
+    /// [`Path`]: struct.Path.html
+    pub fn into_boxed_path(self) -> Box<Path> {
+        let rw = Box::into_raw(self.inner.into_boxed_str()) as *mut Path;
+        unsafe { Box::from_raw(rw) }
+    }
+
+    /// Invokes `capacity` on the underlying instance of `String`.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    /// Invokes `clear` on the underlying instance of `String`.
+    pub fn clear(&mut self) {
+        self.inner.clear()
+    }
+
+    /// Invokes `reserve` on the underlying instance of `String`.
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional)
+    }
+
+    /// Invokes `reserve_exact` on the underlying instance of `String`.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.inner.reserve_exact(additional)
+    }
+
+    /// Invokes `shrink_to_fit` on the underlying instance of `String`.
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit()
+    }
+
+    /// Invokes `shrink_to` on the underlying instance of `String`.
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.inner.shrink_to(min_capacity)
+    }
+}
+
+impl From<&Path> for Box<Path> {
+    fn from(path: &Path) -> Box<Path> {
+        path.to_path_buf().into_boxed_path()
+    }
+}
+
+impl From<Cow<'_, Path>> for Box<Path> {
+    #[inline]
+    fn from(cow: Cow<'_, Path>) -> Box<Path> {
+        match cow {
+            Cow::Borrowed(path) => Box::from(path),
+            Cow::Owned(path) => Box::from(path),
+        }
+    }
+}
+
+impl From<PathBuf> for Box<Path> {
+    /// Converts a `PathBuf` into a `Box<Path>`
+    ///
+    /// This conversion currently should not allocate memory,
+    /// but this behavior is not guaranteed in all future versions.
+    fn from(p: PathBuf) -> Self {
+        p.into_boxed_path()
+    }
+}
+
+impl Clone for Box<Path> {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.to_path_buf().into_boxed_path()
+    }
+}
+
+impl<T: ?Sized + AsRef<str>> From<&T> for PathBuf {
+    fn from(s: &T) -> Self {
+        PathBuf::from(s.as_ref().to_string())
+    }
+}
+
+impl From<String> for PathBuf {
+    /// Converts a [`String`] into a [`PathBuf`]
+    ///
+    /// This conversion does not allocate or copy memory.
+    #[inline]
+    fn from(s: String) -> Self {
+        PathBuf { inner: s }
+    }
+}
+
+impl From<PathBuf> for String {
+    /// Converts a [`PathBuf`] into a [`String`]
+    ///
+    /// This conversion does not allocate or copy memory.
+    fn from(path_buf: PathBuf) -> Self {
+        path_buf.inner
+    }
+}
+
+impl FromStr for PathBuf {
+    type Err = core::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(PathBuf::from(s))
+    }
+}
+
+impl<P: AsRef<Path>> iter::FromIterator<P> for PathBuf {
+    fn from_iter<I: IntoIterator<Item = P>>(iter: I) -> PathBuf {
+        let mut buf = PathBuf::new();
+        buf.extend(iter);
+        buf
+    }
+}
+
+impl<P: AsRef<Path>> iter::Extend<P> for PathBuf {
+    fn extend<I: IntoIterator<Item = P>>(&mut self, iter: I) {
+        iter.into_iter().for_each(move |p| self.push(p.as_ref()));
+    }
+}
+
+impl fmt::Debug for PathBuf {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, formatter)
+    }
+}
+
+impl ops::Deref for PathBuf {
+    type Target = Path;
+    #[inline]
+    fn deref(&self) -> &Path {
+        Path::new(&self.inner)
+    }
+}
+
+impl Borrow<Path> for PathBuf {
+    fn borrow(&self) -> &Path {
+        self.deref()
+    }
+}
+
+impl Default for PathBuf {
+    fn default() -> Self {
+        PathBuf::new()
+    }
+}
+
+impl<'a> From<&'a Path> for Cow<'a, Path> {
+    #[inline]
+    fn from(s: &'a Path) -> Cow<'a, Path> {
+        Cow::Borrowed(s)
+    }
+}
+
+impl<'a> From<PathBuf> for Cow<'a, Path> {
+    #[inline]
+    fn from(s: PathBuf) -> Cow<'a, Path> {
+        Cow::Owned(s)
+    }
+}
+
+impl<'a> From<&'a PathBuf> for Cow<'a, Path> {
+    #[inline]
+    fn from(p: &'a PathBuf) -> Cow<'a, Path> {
+        Cow::Borrowed(p.as_path())
+    }
+}
+
+impl<'a> From<Cow<'a, Path>> for PathBuf {
+    #[inline]
+    fn from(p: Cow<'a, Path>) -> Self {
+        p.into_owned()
+    }
+}
+
+impl From<PathBuf> for Arc<Path> {
+    /// Converts a `PathBuf` into an `Arc` by moving the `PathBuf` data into a new `Arc` buffer.
+    #[inline]
+    fn from(s: PathBuf) -> Arc<Path> {
+        let arc: Arc<str> = Arc::from(s.into_string());
+        unsafe { Arc::from_raw(Arc::into_raw(arc) as *const Path) }
+    }
+}
+
+impl From<&Path> for Arc<Path> {
+    /// Converts a `Path` into an `Arc` by copying the `Path` data into a new `Arc` buffer.
+    #[inline]
+    fn from(s: &Path) -> Arc<Path> {
+        let arc: Arc<str> = Arc::from(s.as_str());
+        unsafe { Arc::from_raw(Arc::into_raw(arc) as *const Path) }
+    }
+}
+
+impl From<PathBuf> for Rc<Path> {
+    /// Converts a `PathBuf` into an `Rc` by moving the `PathBuf` data into a new `Rc` buffer.
+    #[inline]
+    fn from(s: PathBuf) -> Rc<Path> {
+        let rc: Rc<str> = Rc::from(s.into_string());
+        unsafe { Rc::from_raw(Rc::into_raw(rc) as *const Path) }
+    }
+}
+
+impl From<&Path> for Rc<Path> {
+    /// Converts a `Path` into an `Rc` by copying the `Path` data into a new `Rc` buffer.
+    #[inline]
+    fn from(s: &Path) -> Rc<Path> {
+        let rc: Rc<str> = Rc::from(s.as_str());
+        unsafe { Rc::from_raw(Rc::into_raw(rc) as *const Path) }
+    }
+}
+
+impl ToOwned for Path {
+    type Owned = PathBuf;
+    fn to_owned(&self) -> PathBuf {
+        self.to_path_buf()
+    }
+}
+
+impl cmp::PartialEq for PathBuf {
+    fn eq(&self, other: &PathBuf) -> bool {
+        self.components() == other.components()
+    }
+}
+
+impl Hash for PathBuf {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.as_path().hash(h)
+    }
+}
+
+impl cmp::Eq for PathBuf {}
+
+impl cmp::PartialOrd for PathBuf {
+    fn partial_cmp(&self, other: &PathBuf) -> Option<cmp::Ordering> {
+        self.components().partial_cmp(other.components())
+    }
+}
+
+impl cmp::Ord for PathBuf {
+    fn cmp(&self, other: &PathBuf) -> cmp::Ordering {
+        self.components().cmp(other.components())
+    }
+}
+
+impl AsRef<str> for PathBuf {
+    fn as_ref(&self) -> &str {
+        &self.inner[..]
+    }
+}
+
+/// A slice of a path (akin to `str`).
+///
+/// This type supports a number of operations for inspecting a path, including
+/// breaking the path into its components (separated by `/` ), extracting the
+/// file name, determining whether the path is absolute, and so on.
+///
+/// This is an *unsized* type, meaning that it must always be used behind a
+/// pointer like `&` or `Box`. For an owned version of this type,
+/// see [`PathBuf`].
+///
+/// More details about the overall approach can be found in
+/// the [crate documentation](index.html).
+///
+/// # Examples
+///
+/// ```
+/// let path = Path::new("./foo/bar.txt");
+///
+/// let parent = path.parent();
+/// assert_eq!(parent, Some(Path::new("./foo")));
+/// ```
+#[repr(transparent)]
+pub struct Path {
+    inner: str,
+}
+
+/// An error returned from [`Path::strip_prefix`][`strip_prefix`] if the prefix
+/// was not found.
+///
+/// This `struct` is created by the [`strip_prefix`] method on [`Path`].
+/// See its documentation for more.
+///
+/// [`strip_prefix`]: struct.Path.html#method.strip_prefix
+/// [`Path`]: struct.Path.html
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StripPrefixError(());
+
+impl Path {
+    /// Directly wraps a string slice as a `Path` slice.
+    ///
+    /// This is a cost-free conversion.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// Path::new("foo.txt");
+    /// ```
+    ///
+    /// You can create `Path`s from `String`s, or even other `Path`s:
+    ///
+    /// ```
+    /// let string = String::from("foo.txt");
+    /// let from_string = Path::new(&string);
+    /// let from_path = Path::new(&from_string);
+    /// assert_eq!(from_string, from_path);
+    /// ```
+    pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> &Path {
+        unsafe { &*(s.as_ref() as *const str as *const Path) }
+    }
+
+    /// Yields the underlying bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let os_str = Path::new("foo.txt").as_str();
+    /// assert_eq!(os_str, "foo.txt");
+    /// ```
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    /// Yields a `&str` slice if the `Path` is valid unicode.
+    ///
+    /// This conversion may entail doing a check for UTF-8 validity.
+    /// Note that validation is performed because non-UTF-8 strings are
+    /// perfectly valid for some OS.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("foo.txt");
+    /// assert_eq!(path.to_str(), Some("foo.txt"));
+    /// ```
+    pub fn to_str(&self) -> Option<&str> {
+        Some(&self.as_str())
+    }
+
+    /// Converts a `Path` to a `Cow<str>`.
+    ///
+    /// Any non-Unicode sequences are replaced with
+    /// `U+FFFD REPLACEMENT CHARACTER`.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// Calling `to_string_lossy` on a `Path` with valid unicode:
+    ///
+    /// ```
+    /// let path = Path::new("foo.txt");
+    /// assert_eq!(path.to_string_lossy(), "foo.txt");
+    /// ```
+    ///
+    /// Had `path` contained invalid unicode, the `to_string_lossy` call might
+    /// have returned `"fo�.txt"`.
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.inner)
+    }
+
+    /// Converts a `Path` to an owned [`PathBuf`].
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path_buf = Path::new("foo.txt").to_path_buf();
+    /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
+    /// ```
+    pub fn to_path_buf(&self) -> PathBuf {
+        PathBuf::from(&self.inner)
+    }
+
+    /// Returns `true` if the `Path` is absolute, i.e., if it is independent of
+    /// the current directory.
+    ///
+    /// A path is absolute if it starts with the root, so `is_absolute` and
+    /// [`has_root`] are equivalent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(!Path::new("foo.txt").is_absolute());
+    /// ```
+    pub fn is_absolute(&self) -> bool {
+        self.has_root()
+    }
+
+    /// Returns `true` if the `Path` is relative, i.e., not absolute.
+    ///
+    /// See [`is_absolute`]'s documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(Path::new("foo.txt").is_relative());
+    /// ```
+    ///
+    /// [`is_absolute`]: #method.is_absolute
+    pub fn is_relative(&self) -> bool {
+        !self.is_absolute()
+    }
+
+    /// Returns `true` if the `Path` has a root.
+    ///
+    /// A path has a root if it begins with `/`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(Path::new("/etc/passwd").has_root());
+    /// ```
+    pub fn has_root(&self) -> bool {
+        self.components().has_root()
+    }
+    /// Checks if the path ends with a separator.
+    ///
+    /// This function checks if the last character of the path string is a separator character.
+    /// If the path is empty, it returns `false`.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if the path ends with a separator.
+    /// * `false` if the path does not end with a separator or if the path is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use your_module::Path;
+    ///
+    /// let p = Path::new("/some/path/");
+    /// assert_eq!(p.has_last_separator(), true);
+    ///
+    /// let p = Path::new("/some/path");
+    /// assert_eq!(p.has_last_separator(), false);
+    /// ```
+    pub fn has_last_separator(&self) -> bool {
+        self.as_str()
+            .chars()
+            .last()
+            .map(is_separator)
+            .unwrap_or(false)
+    }
+
+    /// Returns the `Path` without its final component, if there is one.
+    ///
+    /// Returns `None` if the path terminates in a root or prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("/foo/bar");
+    /// let parent = path.parent().unwrap();
+    /// assert_eq!(parent, Path::new("/foo"));
+    ///
+    /// let grand_parent = parent.parent().unwrap();
+    /// assert_eq!(grand_parent, Path::new("/"));
+    /// assert_eq!(grand_parent.parent(), None);
+    /// ```
+    pub fn parent(&self) -> Option<&Path> {
+        let mut comps = self.components();
+        let comp = comps.next_back();
+        comp.and_then(|p| match p {
+            Component::Normal(_) | Component::CurDir | Component::ParentDir => {
+                Some(comps.as_path())
+            }
+            _ => None,
+        })
+    }
+
+    /// Produces an iterator over `Path` and its ancestors.
+    ///
+    /// The iterator will yield the `Path` that is returned if the [`parent`] method is used zero
+    /// or more times. That means, the iterator will yield `&self`, `&self.parent().unwrap()`,
+    /// `&self.parent().unwrap().parent().unwrap()` and so on. If the [`parent`] method returns
+    /// `None`, the iterator will do likewise. The iterator will always yield at least one value,
+    /// namely `&self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut ancestors = Path::new("/foo/bar").ancestors();
+    /// assert_eq!(ancestors.next(), Some(Path::new("/foo/bar")));
+    /// assert_eq!(ancestors.next(), Some(Path::new("/foo")));
+    /// assert_eq!(ancestors.next(), Some(Path::new("/")));
+    /// assert_eq!(ancestors.next(), None);
+    /// ```
+    ///
+    /// [`parent`]: struct.Path.html#method.parent
+    pub fn ancestors(&self) -> Ancestors<'_> {
+        Ancestors { next: Some(&self) }
+    }
+
+    /// Returns the final component of the `Path`, if there is one.
+    ///
+    /// If the path is a normal file, this is the file name. If it's the path of a directory, this
+    /// is the directory name.
+    ///
+    /// Returns `None` if the path terminates in `..`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(Some("bin"), Path::new("/usr/bin/").file_name());
+    /// assert_eq!(Some("foo.txt"), Path::new("tmp/foo.txt").file_name());
+    /// assert_eq!(Some("foo.txt"), Path::new("foo.txt/.").file_name());
+    /// assert_eq!(Some("foo.txt"), Path::new("foo.txt/.//").file_name());
+    /// assert_eq!(None, Path::new("foo.txt/..").file_name());
+    /// assert_eq!(None, Path::new("/").file_name());
+    /// ```
+    pub fn file_name(&self) -> Option<&str> {
+        self.components().next_back().and_then(|p| match p {
+            Component::Normal(p) => Some(p),
+            _ => None,
+        })
+    }
+
+    /// Returns a path that, when joined onto `base`, yields `self`.
+    ///
+    /// # Errors
+    ///
+    /// If `base` is not a prefix of `self` (i.e., [`starts_with`]
+    /// returns `false`), returns `Err`.
+    ///
+    /// [`starts_with`]: #method.starts_with
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("/test/haha/foo.txt");
+    ///
+    /// assert_eq!(path.strip_prefix("/"), Ok(Path::new("test/haha/foo.txt")));
+    /// assert_eq!(path.strip_prefix("/test"), Ok(Path::new("haha/foo.txt")));
+    /// assert_eq!(path.strip_prefix("/test/"), Ok(Path::new("haha/foo.txt")));
+    /// assert_eq!(path.strip_prefix("/test/haha/foo.txt"), Ok(Path::new("")));
+    /// assert_eq!(path.strip_prefix("/test/haha/foo.txt/"), Ok(Path::new("")));
+    /// assert_eq!(path.strip_prefix("test").is_ok(), false);
+    /// assert_eq!(path.strip_prefix("/haha").is_ok(), false);
+    ///
+    /// let prefix = PathBuf::from("/test/");
+    /// assert_eq!(path.strip_prefix(prefix), Ok(Path::new("haha/foo.txt")));
+    /// ```
+    pub fn strip_prefix<P>(&self, base: P) -> Result<&Path, StripPrefixError>
+    where
+        P: AsRef<Path>,
+    {
+        self._strip_prefix(base.as_ref())
+    }
+
+    fn _strip_prefix(&self, base: &Path) -> Result<&Path, StripPrefixError> {
+        iter_after(self.components(), base.components())
+            .map(|c| c.as_path())
+            .ok_or(StripPrefixError(()))
+    }
+
+    /// Determines whether `base` is a prefix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("/etc/passwd");
+    ///
+    /// assert!(path.starts_with("/etc"));
+    /// assert!(path.starts_with("/etc/"));
+    /// assert!(path.starts_with("/etc/passwd"));
+    /// assert!(path.starts_with("/etc/passwd/"));
+    ///
+    /// assert!(!path.starts_with("/e"));
+    /// ```
+    pub fn starts_with<P: AsRef<Path>>(&self, base: P) -> bool {
+        self._starts_with(base.as_ref())
+    }
+
+    fn _starts_with(&self, base: &Path) -> bool {
+        iter_after(self.components(), base.components()).is_some()
+    }
+
+    /// Determines whether `child` is a suffix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("/etc/passwd");
+    ///
+    /// assert!(path.ends_with("passwd"));
+    /// ```
+    pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool {
+        self._ends_with(child.as_ref())
+    }
+
+    fn _ends_with(&self, child: &Path) -> bool {
+        iter_after(self.components().rev(), child.components().rev()).is_some()
+    }
+
+    /// Creates an owned [`PathBuf`] with `path` adjoined to `self`.
+    ///
+    /// See [`PathBuf::push`] for more details on what it means to adjoin a path.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::push`]: struct.PathBuf.html#method.push
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(Path::new("/etc").join("passwd"), PathBuf::from("/etc/passwd"));
+    /// ```
+    #[must_use]
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        self._join(path.as_ref())
+    }
+
+    fn _join(&self, path: &Path) -> PathBuf {
+        let mut buf = self.to_path_buf();
+        buf.push(path);
+        buf
+    }
+
+    /// Creates an owned [`PathBuf`] like `self` but with the given file name.
+    ///
+    /// See [`PathBuf::set_file_name`] for more details.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::set_file_name`]: struct.PathBuf.html#method.set_file_name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path = Path::new("/tmp/foo.txt");
+    /// assert_eq!(path.with_file_name("bar.txt"), PathBuf::from("/tmp/bar.txt"));
+    ///
+    /// let path = Path::new("/tmp");
+    /// assert_eq!(path.with_file_name("var"), PathBuf::from("/var"));
+    /// ```
+    pub fn with_file_name<S: AsRef<str>>(&self, file_name: S) -> PathBuf {
+        self._with_file_name(file_name.as_ref())
+    }
+
+    fn _with_file_name(&self, file_name: &str) -> PathBuf {
+        let mut buf = self.to_path_buf();
+        buf.set_file_name(file_name);
+        buf
+    }
+
+    /// Produces an iterator over the [`Component`]s of the path.
+    ///
+    /// When parsing the path, there is a small amount of normalization:
+    ///
+    /// * Repeated separators are ignored, so `a/b` and `a//b` both have
+    ///   `a` and `b` as components.
+    ///
+    /// * Occurrences of `.` are normalized away, except if they are at the
+    ///   beginning of the path. For example, `a/./b`, `a/b/`, `a/b/.` and
+    ///   `a/b` all have `a` and `b` as components, but `./a/b` starts with
+    ///   an additional [`Component::CurDir`] component.
+    ///
+    /// * A trailing slash is normalized away, `/a/b` and `/a/b/` are equivalent.
+    ///
+    /// Note that no other normalization takes place; in particular, `a/c`
+    /// and `a/b/../c` are distinct, to account for the possibility that `b`
+    /// is a symbolic link (so its parent isn't `a`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut components = Path::new("/tmp/foo.txt").components();
+    ///
+    /// assert_eq!(components.next(), Some(Component::RootDir));
+    /// assert_eq!(components.next(), Some(Component::Normal("tmp")));
+    /// assert_eq!(components.next(), Some(Component::Normal("foo.txt")));
+    /// assert_eq!(components.next(), None)
+    /// ```
+    pub fn components(&self) -> Components<'_> {
+        Components {
+            path: &self.inner,
+            has_root: has_root(&self.inner),
+            front: State::Prefix,
+            back: State::Body,
+        }
+    }
+
+    /// Produces an iterator over the path's components viewed as `str`
+    /// slices.
+    ///
+    /// For more information about the particulars of how the path is separated
+    /// into components, see [`components`].
+    ///
+    /// [`components`]: #method.components
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut it = Path::new("/tmp/foo.txt").iter();
+    /// assert_eq!(it.next(), Some("/"));
+    /// assert_eq!(it.next(), Some("tmp"));
+    /// assert_eq!(it.next(), Some("foo.txt"));
+    /// assert_eq!(it.next(), None)
+    /// ```
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            inner: self.components(),
+        }
+    }
+
+    /// Returns a newtype that implements Display for safely printing paths
+    /// that may contain non-Unicode data.
+    pub fn display(&self) -> Display<'_> {
+        Display { path: self }
+    }
+}
+
+impl AsRef<str> for Path {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl fmt::Debug for Path {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, formatter)
+    }
+}
+
+impl cmp::PartialEq for Path {
+    fn eq(&self, other: &Path) -> bool {
+        self.components().eq(other.components())
+    }
+}
+
+impl Hash for Path {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        for component in self.components() {
+            component.hash(h);
+        }
+    }
+}
+
+impl cmp::Eq for Path {}
+
+impl cmp::PartialOrd for Path {
+    fn partial_cmp(&self, other: &Path) -> Option<cmp::Ordering> {
+        self.components().partial_cmp(other.components())
+    }
+}
+
+impl cmp::Ord for Path {
+    fn cmp(&self, other: &Path) -> cmp::Ordering {
+        self.components().cmp(other.components())
+    }
+}
+
+impl AsRef<Path> for Path {
+    fn as_ref(&self) -> &Path {
+        self
+    }
+}
+
+impl AsRef<Path> for str {
+    #[inline]
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
+impl AsRef<Path> for String {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
+impl AsRef<Path> for PathBuf {
+    #[inline]
+    fn as_ref(&self) -> &Path {
+        self
+    }
+}
+
+impl<'a> IntoIterator for &'a PathBuf {
+    type Item = &'a str;
+    type IntoIter = Iter<'a>;
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Path {
+    type Item = &'a str;
+    type IntoIter = Iter<'a>;
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+macro_rules! impl_cmp {
+    ($lhs:ty, $rhs: ty) => {
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                <Path as PartialEq>::eq(self, other)
+            }
+        }
+
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                <Path as PartialEq>::eq(self, other)
+            }
+        }
+
+        impl<'a, 'b> PartialOrd<$rhs> for $lhs {
+            #[inline]
+            fn partial_cmp(&self, other: &$rhs) -> Option<cmp::Ordering> {
+                <Path as PartialOrd>::partial_cmp(self, other)
+            }
+        }
+
+        impl<'a, 'b> PartialOrd<$lhs> for $rhs {
+            #[inline]
+            fn partial_cmp(&self, other: &$lhs) -> Option<cmp::Ordering> {
+                <Path as PartialOrd>::partial_cmp(self, other)
+            }
+        }
+    };
+}
+
+impl_cmp!(PathBuf, Path);
+impl_cmp!(PathBuf, &'a Path);
+impl_cmp!(Cow<'a, Path>, Path);
+impl_cmp!(Cow<'a, Path>, &'b Path);
+impl_cmp!(Cow<'a, Path>, PathBuf);
+
+impl fmt::Display for StripPrefixError {
+    #[allow(deprecated, deprecated_in_future)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "prefix not found".fmt(f)
+    }
+}
+
+pub struct Display<'a> {
+    path: &'a Path,
+}
+
+impl fmt::Debug for Display<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.path, formatter)
+    }
+}
+
+impl fmt::Display for Display<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.path.as_str(), formatter)
+    }
+}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -87,8 +87,14 @@ fn finish_boot() {
 fn load_init_process() {
     let mut init_file = fs::File::open("/init").expect("Could not find `init` file");
     let elf = Elf::load(&mut init_file).expect("Could not load init file");
-    let mut process = Process::allocate_process(0, &elf, &mut init_file, Vec::new())
-        .expect("Could not allocate process for `init`");
+    let mut process = Process::allocate_process(
+        0,
+        &elf,
+        &mut init_file,
+        Vec::new(),
+        fs::Directory::open("/").expect("No root"),
+    )
+    .expect("Could not allocate process for `init`");
     assert!(process.id() == 0, "Must be the first process");
 
     // add the console to `init` manually, after that processes will either inherit it or open a pipe or something

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -117,6 +117,8 @@ pub struct Process {
 
     argv: Vec<String>,
 
+    current_dir: fs::Directory,
+
     stack_ptr_end: usize,
     stack_size: usize,
 
@@ -136,6 +138,7 @@ impl Process {
         elf: &elf::Elf,
         file: &mut fs::File,
         argv: Vec<String>,
+        current_dir: fs::Directory,
     ) -> Result<Self, ProcessError> {
         let id = PROCESS_ID_ALLOCATOR.allocate();
         let mut vm = virtual_memory_mapper::clone_current_vm_as_user();
@@ -189,6 +192,7 @@ impl Process {
             open_filesystem_nodes: BTreeMap::new(),
             file_index_allocator: GoingUpAllocator::new(),
             argv,
+            current_dir,
             stack_ptr_end: stack_end - 8, // 8 bytes for padding
             stack_size,
             heap_start,
@@ -327,6 +331,14 @@ impl Process {
         }
 
         Some(old_end)
+    }
+
+    pub fn get_current_dir(&self) -> &fs::Directory {
+        &self.current_dir
+    }
+
+    pub fn set_current_dir(&mut self, current_dir: fs::Directory) {
+        self.current_dir = current_dir;
     }
 }
 

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -476,11 +476,11 @@ fn sys_get_cwd(all_state: &mut InterruptAllSavedState) -> SyscallResult {
 
     let needed_bytes = with_current_process(|process| -> Result<usize, SyscallError> {
         let cwd = process.get_current_dir().path();
-        let needed_bytes = cwd.as_bytes().len();
+        let needed_bytes = cwd.as_str().as_bytes().len();
         if needed_bytes > len {
             return Err(SyscallError::BufferTooSmall);
         }
-        buf[..needed_bytes].copy_from_slice(cwd.as_bytes());
+        buf[..needed_bytes].copy_from_slice(cwd.as_str().as_bytes());
         Ok(needed_bytes)
     })?;
 

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amjad_os_kernel_user_link"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -6,7 +6,7 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 13;
+pub const NUM_SYSCALLS: usize = 15;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
@@ -22,6 +22,8 @@ mod numbers {
     pub const SYS_STAT: u64 = 10;
     pub const SYS_OPEN_DIR: u64 = 11;
     pub const SYS_READ_DIR: u64 = 12;
+    pub const SYS_GET_CWD: u64 = 13;
+    pub const SYS_CHDIR: u64 = 14;
 }
 pub use numbers::*;
 
@@ -232,6 +234,7 @@ pub enum SyscallError {
     ProcessStillRunning = 12,
     IsNotDirectory = 13,
     IsDirectory = 14,
+    BufferTooSmall = 15,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -320,6 +323,7 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::ProcessStillRunning => 12 << 56,
                 SyscallError::IsNotDirectory => 13 << 56,
                 SyscallError::IsDirectory => 14 << 56,
+                SyscallError::BufferTooSmall => 15 << 56,
             };
 
             err_upper | (1 << 63)
@@ -371,6 +375,7 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             12 => SyscallError::ProcessStillRunning,
             13 => SyscallError::IsNotDirectory,
             14 => SyscallError::IsDirectory,
+            15 => SyscallError::BufferTooSmall,
             _ => invalid_error_code(()),
         };
         SyscallResult::Err(err)

--- a/libraries/user_std/Cargo.toml
+++ b/libraries/user_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amjad_os_user_std"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]
@@ -14,7 +14,7 @@ categories = ["os"]
 
 [dependencies]
 increasing_heap_allocator = { version="0.1.3", path = "../increasing_heap_allocator" }
-kernel_user_link = { version="0.1.4", path = "../kernel_user_link", package = "amjad_os_kernel_user_link" }
+kernel_user_link = { version="0.1.5", path = "../kernel_user_link", package = "amjad_os_kernel_user_link" }
 
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }

--- a/userspace/shell/src/ls.rs
+++ b/userspace/shell/src/ls.rs
@@ -60,8 +60,8 @@ fn main() -> ExitCode {
     let args = std::env::args().collect::<Vec<_>>();
 
     if args.len() < 2 {
-        println!("Usage: {} [paths...]", args[0]);
-        return ExitCode::FAILURE;
+        ls(".", false);
+        return ExitCode::SUCCESS;
     }
 
     let print_parent = args.len() > 2;

--- a/userspace/shell/src/shell.rs
+++ b/userspace/shell/src/shell.rs
@@ -1,10 +1,42 @@
 #![feature(restricted_std)]
 
 use std::{
+    borrow::Cow,
     io::{self, Write},
+    path::Path,
     process::Command,
     string::String,
 };
+
+/// Return `true` if we are the one handling this command, otherwise return `false`
+/// so that the command is executed as a normal process.
+fn handle_internal_cmds(cmd: &str, args: &[&str]) -> bool {
+    match cmd {
+        "exit" => {
+            println!("Goodbye!");
+            std::process::exit(0);
+        }
+        "cd" => {
+            if args.len() == 0 {
+                println!("cd: missing argument");
+            } else {
+                let path = args[0];
+                match std::env::set_current_dir(path) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        println!("cd: {e}");
+                    }
+                }
+            }
+        }
+        "pwd" => {
+            println!("{}", std::env::current_dir().unwrap().display());
+        }
+        _ => return false,
+    }
+
+    true
+}
 
 fn main() {
     let mut old_result = None;
@@ -27,11 +59,22 @@ fn main() {
         }
 
         let cmd = args[0];
-        // TODO: add support for relative paths and other stuff, for now we must specify the full path
-        let cmd_path = format!("/{cmd}");
         let remaining_args = &args[1..];
 
-        let result = match Command::new(cmd_path).args(remaining_args).spawn() {
+        // handle internal commands
+        if handle_internal_cmds(cmd, remaining_args) {
+            continue;
+        }
+
+        // if this cmd exsist in the current directory, use it
+        // otherwise, use the root
+        let cmd_path: Cow<'_, str> = if Path::new(cmd).exists() {
+            cmd.into()
+        } else {
+            format!("/{}", cmd).into()
+        };
+
+        let result = match Command::new(cmd_path.as_ref()).args(remaining_args).spawn() {
             Ok(mut proc) => proc.wait().unwrap(),
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => {


### PR DESCRIPTION
Fixes #29 
Fixes #41 

Quite a large PR including several changes:

- We now have `current_dir` inside a `Process` and we handle all path arguments in syscalls as relative if the path doesn't start with `/`.
- With the above, we added `sys_chdir` and `sys_get_cwd` to set/get the `current_dir`. 
    - The directory must be a valid directory when setting it, currently we don't have **write** support in the fat filesystem yet, so folders won't change anyway but we should be careful of removing/moving the `current_dir` while being used.
- Added `fs::path::Path` and `fs::path::PathBuf` in the kernel which is very similar API to the `Path` in `std`
- Better handling for traversing in the fat implementation, though not the best still, need to be improved.
- Added `chdir` and `getcwd` in `std` in `rust` and related items there.
- Added `cd` and `pwd` commands in the shell
- Added bonus (not really related) `exit` command in the shell, which just exists, init will create a new shell.