### PR TITLE
Better handling for rust toolchain and `std`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[unstable]
-build-std-features = ["compiler-builtins-mem"]
-build-std = ["core", "alloc", "compiler_builtins"]
-
-[build]
-target = "x86-64-amjad_os.json"
-
-[target.'cfg(target_os = "none")']
-runner = "qemu-system-x86_64 -serial mon:stdio -m 512 -kernel"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,23 @@ jobs:
       - uses: davidB/rust-cargo-make@v1
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: 'false'
+      - name: submodule fetch
+        run: git submodule update --init --recursive
       - name: Build kernel
         run: cargo make kernel_iso
+      - name: Restore cached rust build
+        id: cache-os-rust-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: extern/rust/build
+          key: ${{ runner.os }}-rust-build-toolchain
       - name: Build filesystem programs
         run: cargo make filesystem
+      - name: Save cache rust build
+        id: cache-os-rust-save
+        uses: actions/cache/save@v4
+        with:
+          path: extern/rust/build
+          key: ${{ steps.cache-os-rust-restore.outputs.cache-primary-key }}
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "extern/rust"]
 	path = extern/rust
 	url = https://github.com/Amjad50/rust.git
-	branch = amjad50_os
+	branch = amjad50_os_new_target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "amjad_os_kernel_user_link"
 version = "0.1.5"
 dependencies = [
@@ -28,50 +22,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "compiler_builtins"
 version = "0.1.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3686cc48897ce1950aa70fd595bd2dc9f767a3c4cca4cd17b2cb52a2d37e6eb4"
-
-[[package]]
-name = "cupid"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bad352a84b567cc38a5854e3aa8ee903cb8519a25d0b799b739bafffd1f91a1"
-dependencies = [
- "gcc",
- "rustc_version",
-]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "increasing_heap_allocator"
@@ -85,10 +39,6 @@ dependencies = [
 [[package]]
 name = "init"
 version = "0.1.0"
-dependencies = [
- "panic_abort",
- "std",
-]
 
 [[package]]
 name = "kernel"
@@ -97,32 +47,6 @@ dependencies = [
  "amjad_os_kernel_user_link",
  "increasing_heap_allocator",
 ]
-
-[[package]]
-name = "libc"
-version = "0.2.151"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
-
-[[package]]
-name = "panic_abort"
-version = "0.0.0"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "profiler_builtins"
-version = "0.0.0"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-std-workspace-alloc"
@@ -137,58 +61,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "shell"
 version = "0.1.0"
-dependencies = [
- "panic_abort",
- "std",
-]
-
-[[package]]
-name = "std"
-version = "0.0.0"
-dependencies = [
- "amjad_os_user_std",
- "cfg-if",
- "hashbrown",
- "panic_abort",
- "profiler_builtins",
- "rustc-demangle",
- "std_detect",
-]
-
-[[package]]
-name = "std_detect"
-version = "0.1.5"
-dependencies = [
- "cfg-if",
- "compiler_builtins",
- "cupid",
- "libc",
- "rustc-std-workspace-alloc",
- "rustc-std-workspace-core",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ members = [
     "kernel",
     "userspace/init", "userspace/shell", "libraries/increasing_heap_allocator", "libraries/user_std",
 ]
+
+exclude = ["extern"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,41 +1,23 @@
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 PROFILE = { source = "${CARGO_MAKE_CARGO_PROFILE}", default_value = "dev", mapping = {"dev" = "debug", "release" = "release" } }
-OUT_DIR = "${CARGO_MAKE_CRATE_CUSTOM_TRIPLE_TARGET_DIRECTORY}/${PROFILE}"
-KERNEL_PATH = "${OUT_DIR}/kernel"
-ISO_PATH = "${OUT_DIR}/kernel.iso"
-GRUB_CFG_PATH = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/kernel/grub.cfg"
-GRUB_PATH = "${CARGO_MAKE_CRATE_CUSTOM_TRIPLE_TARGET_DIRECTORY}/${PROFILE}/grub"
 FILESYSTEM_PATH = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/filesystem"
+ISO_PATH = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/${PROFILE}/kernel.iso"
 QEMU_ARGS = "-serial mon:stdio -m 512 -boot d -drive format=raw,file=fat:rw:filesystem"
 # UEFI_IMAGE = "" # external: change to a path to a UEFI image to enable UEFI booting (like, /usr/share/edk2-ovmf/x64/OVMF_CODE.fd)
 QEMU_UEFI_ARGS = { value = "-bios ${UEFI_IMAGE}", condition = { env_true = ["UEFI_IMAGE"] } }
 
-[tasks.build_member]
-workspace = true
-command = "cargo"
-condition= {files_modified = {input=["${CARGO_MAKE_WORKING_DIRECTORY}/src/**/*", "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml"], output=["${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}"]}}
-args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
-
-[tasks.copy_to_fs]
-workspace = true
-condition= {files_modified = {input=["${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
-dependencies = ["build_member"]
-command = "cp"
-args = ["-r", "${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}", "${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]
-
-[tasks.extra_copy_to_fs]
+[tasks.toolchain]
 workspace = false
-dependencies = ["build_member"]
-condition= {files_modified = {input=["${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
-command = "cp"
-args = ["-r", "${OUT_DIR}/echo", "${OUT_DIR}/cat", "${OUT_DIR}/ls", "${OUT_DIR}/xxd", "${FILESYSTEM_PATH}/"]
+cwd = "userspace"
+command = "makers"
+args = ["--makefile", "Makefile.toolchain.toml", "install_user_toolchain"]
 
 [tasks.filesystem]
 workspace = false
-# empty array means all members (not sure why need to be explicit)
-env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS=[], CARGO_MAKE_WORKSPACE_SKIP_MEMBERS=["kernel", "libraries/*"] }
-run_task = { name = ["copy_to_fs", "extra_copy_to_fs"], fork = true }
+cwd = "userspace"
+command = "makers"
+args = ["--makefile", "Makefile.toml", "filesystem"]
 
 # kernel tasks
 [tasks.kernel_iso]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,14 +10,14 @@ QEMU_UEFI_ARGS = { value = "-bios ${UEFI_IMAGE}", condition = { env_true = ["UEF
 [tasks.toolchain]
 workspace = false
 cwd = "userspace"
-command = "makers"
-args = ["--makefile", "Makefile.toolchain.toml", "install_user_toolchain"]
+command = "cargo-make"
+args = ["make", "--makefile", "Makefile.toolchain.toml", "install_user_toolchain"]
 
 [tasks.filesystem]
 workspace = false
 cwd = "userspace"
-command = "makers"
-args = ["--makefile", "Makefile.toml", "filesystem"]
+command = "cargo-make"
+args = ["make", "--makefile", "Makefile.toml", "filesystem"]
 
 # kernel tasks
 [tasks.kernel_iso]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# Kernel
-
-This is a kernel written in rust from scratch.
+# OS
+This is an OS written in rust from scratch.
 
 The plan is to learn everything about the kernel and low level details, so I'm not using any libraries, even though
 there are a lot of good libraries that do everything I'm doing (ex. handling GDT/IDT/etc...).
@@ -20,9 +19,19 @@ For building the ISO image, you can use `make` but you need to have other depend
 ```
 xorriso mtools grub-pc-bin qemu-system-x86
 ```
-Build:
+Build kernel iso:
 ```sh
 cargo make kernel_iso
+```
+Build userspace programs into [`filesystem`](filesystem) directory (used by qemu):
+> Note: this will build the `rust` toolchain if it hasn't been built before (might take some time)
+```sh
+cargo make filesystem
+```
+(optional) Install the toolchain into [`extern/toolchain`](extern/toolchain) directory:
+> You can then use `rustup toolchain link ...` to link to this folder
+```sh
+cargo make toolchain
 ```
 For running:
 ```sh
@@ -40,7 +49,7 @@ And to boot QEMU in debug mode you can use (it will wait for debugger on port `:
 cargo make run_iso_gdb
 ```
 
-## Information about the kernel
+## Kernel
 ### Booting
 Currently, this project compiles a multiboot2 ELF64 kernel that can be booted by several bootloaders,
 I'm using GRUB using a bootloader like GRUB.
@@ -56,9 +65,18 @@ After setting up long-mode, we jump to rust code, and start executing the `kerne
 when we jump to the `kernel_main`, we have mapped some basic parts of the kernel to virtual memory, a basic GDT with no IDT, and we have interrupts still disabled.
 So we setup all of those and the rest of the OS then.
 
+## Userland
+
+Currently, the main focus for running userspace applications is by having `std` in rust, as all userspace applications
+are build in rust, this is the primary support. Thus, we don't have `libc` for now. We have [`user_std`](user_std)
+which is the main dependancy for that `std` uses.
+
+We have our own target `x86_64-unknown-amjad_os` which is a custom target for our OS, added to custom fork
+of `rustc` in here: [`rust`].
+
 ## Demo to userspace programs
 
-Currently we have a basic shell, and I'm using a clone of [`rust`] with my target. Anyway, here is a demo of a program I can run on my OS, [see the repo here](https://github.com/Amjad50/lprs)
+Here is a demo of a program I can run on my OS, [see the repo here](https://github.com/Amjad50/lprs)
 ![gif demo](https://github.com/Amjad50/lprs/blob/master/demo.gif)
 
 ## License

--- a/extern/toolchain/config.toml
+++ b/extern/toolchain/config.toml
@@ -1,0 +1,31 @@
+# Use different pre-set defaults than the global defaults.
+#
+# See `src/bootstrap/defaults` for more information.
+# Note that this has no default value (x.py uses the defaults in `config.example.toml`).
+# profile = 'dist'
+change-id = 102579
+
+[llvm]
+download-ci-llvm = true
+# targets = "X86"
+
+[build]
+target = ["x86_64-unknown-amjad_os", "x86_64-unknown-linux-gnu"]
+docs = false
+
+# Arguments passed to the `./configure` script, used during distcheck. You
+# probably won't fill this in but rather it's filled in by the `./configure`
+# script. Useful for debugging.
+configure-args = []
+
+[install]
+prefix = "../toolchain"
+sysconfdir = "../toolchain/etc"
+
+[rust]
+lld = true
+
+[target.x86_64-unknown-linux-gnu]
+
+[dist]
+

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -1,0 +1,6 @@
+[unstable]
+build-std-features = ["compiler-builtins-mem"]
+build-std = ["core", "alloc", "compiler_builtins"]
+
+[build]
+target = "x86-64-os.json"

--- a/kernel/Makefile.toml
+++ b/kernel/Makefile.toml
@@ -1,13 +1,12 @@
 [env]
-CARGO_BUILD_TARGET = "${CARGO_MAKE_WORKING_DIRECTORY}/x86-64-os.json"
-KERNEL_PATH = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86-64-os/${PROFILE}/kernel"
+KERNEL_PATH = "${CARGO_MAKE_CRATE_CUSTOM_TRIPLE_TARGET_DIRECTORY}/${PROFILE}/kernel"
 GRUB_CFG_PATH = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/kernel/grub.cfg"
 GRUB_PATH = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/${PROFILE}/grub"
 
 [tasks.build]
 command = "cargo"
 condition= {files_modified = {input=["${CARGO_MAKE_WORKING_DIRECTORY}/src/**/*", "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml"], output=["${KERNEL_PATH}"]}}
-args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "-Z", "build-std=core,alloc,compiler_builtins", "-Z", "build-std-features=compiler-builtins-mem"]
+args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
 
 [tasks.iso_create_grub]
 private = true

--- a/kernel/Makefile.toml
+++ b/kernel/Makefile.toml
@@ -1,7 +1,13 @@
+[env]
+CARGO_BUILD_TARGET = "${CARGO_MAKE_WORKING_DIRECTORY}/x86-64-os.json"
+KERNEL_PATH = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86-64-os/${PROFILE}/kernel"
+GRUB_CFG_PATH = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/kernel/grub.cfg"
+GRUB_PATH = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/${PROFILE}/grub"
+
 [tasks.build]
 command = "cargo"
-condition= {files_modified = {input=["${CARGO_MAKE_WORKING_DIRECTORY}/src/**/*", "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml"], output=["${OUT_DIR}/${CARGO_MAKE_PROJECT_NAME}"]}}
-args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
+condition= {files_modified = {input=["${CARGO_MAKE_WORKING_DIRECTORY}/src/**/*", "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml"], output=["${KERNEL_PATH}"]}}
+args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "-Z", "build-std=core,alloc,compiler_builtins", "-Z", "build-std-features=compiler-builtins-mem"]
 
 [tasks.iso_create_grub]
 private = true

--- a/kernel/x86-64-os.json
+++ b/kernel/x86-64-os.json
@@ -5,7 +5,6 @@
     "target-endian": "little",
     "target-pointer-width": "64",
     "target-c-int-width": "32",
-    "os": "amjad_os",
     "executables": true,
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",

--- a/libraries/user_std/README.md
+++ b/libraries/user_std/README.md
@@ -1,5 +1,8 @@
 ### Amjad OS: Userspace std
 
+[![Crates.io user_std](https://img.shields.io/crates/v/amjad_os_user_std)](https://crates.io/crates/amjad_os_user_std)
+[![docs.rs (with version)](https://img.shields.io/docsrs/amjad_os_user_std/latest)](https://docs.rs/amjad_os_user_std/latest/amjad_os_user_std/)
+
 This is a small library acting as a sort of `libc` for my kernel. This is imported by `std` in `rust` and provide the `sys`
 implementation for most features.
 

--- a/userspace/.cargo/config.toml
+++ b/userspace/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-amjad_os"

--- a/userspace/.cargo/config.toml
+++ b/userspace/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
+rustc-wrapper = ""  # sccache is giving weird bugs when recompiling std
 target = "x86_64-unknown-amjad_os"

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
-RUSTC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/rustc"
-RUSTDOC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/rustdoc"
+RUSTC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/bin/rustc"
+RUSTDOC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/rustdoc"
 USER_OUTDIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86_64-unknown-amjad_os/${PROFILE}"
 
 CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell"]

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -6,12 +6,16 @@ USER_OUTDIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86_64-unknown-amjad_os/${PR
 CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell"]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_WORKSPACE_EMULATION = true
+# BUG in cargo-make, it uses `cargo` to get metadata about `rustc`, and it uses the system toolchain
+# not our custom one, and in that toolchain, we don't have our target, so it fails.
+# we put a target here, but we replace it in the `--target` argument of the build command
+CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu"
 
 # copy found in the root makefile
 [tasks.toolchain]
 workspace = false
 command = "makers"
-args = ["--makefile", "Makefile.toolchain.toml", "install_user_toolchain"]
+args = ["--makefile", "Makefile.toolchain.toml", "build_user_toolchain"]
 
 [tasks.build_member]
 workspace = true

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -14,8 +14,8 @@ CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu"
 # copy found in the root makefile
 [tasks.toolchain]
 workspace = false
-command = "makers"
-args = ["--makefile", "Makefile.toolchain.toml", "build_user_toolchain"]
+command = "cargo-make"
+args = ["make", "--makefile", "Makefile.toolchain.toml", "build_user_toolchain"]
 
 [tasks.build_member]
 workspace = true

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -7,6 +7,12 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell"]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_WORKSPACE_EMULATION = true
 
+# copy found in the root makefile
+[tasks.toolchain]
+workspace = false
+command = "makers"
+args = ["--makefile", "Makefile.toolchain.toml", "install_user_toolchain"]
+
 [tasks.build_member]
 workspace = true
 command = "cargo"
@@ -22,6 +28,7 @@ args = ["-r", "${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}", "${FILESYSTEM_PATH}/$
 
 [tasks.filesystem]
 workspace = false
+dependencies = ["toolchain"]
 env = {CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = []}
 run_task = {name=["copy_to_fs", "extra_copy_to_fs"], fork=true}
 

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -1,0 +1,33 @@
+[env]
+RUSTC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/rustc"
+RUSTDOC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/rustdoc"
+USER_OUTDIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86_64-unknown-amjad_os/${PROFILE}"
+
+CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell"]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+CARGO_MAKE_WORKSPACE_EMULATION = true
+
+[tasks.build_member]
+workspace = true
+command = "cargo"
+condition= {files_modified = {input=["${CARGO_MAKE_WORKING_DIRECTORY}/src/**/*", "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml"], output=["${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}"]}}
+args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "--target", "x86_64-unknown-amjad_os"]
+
+[tasks.copy_to_fs]
+workspace = true
+condition= {files_modified = {input=["${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
+dependencies = ["build_member"]
+command = "cp"
+args = ["-r", "${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}", "${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]
+
+[tasks.filesystem]
+workspace = false
+env = {CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = []}
+run_task = {name=["copy_to_fs", "extra_copy_to_fs"], fork=true}
+
+[tasks.extra_copy_to_fs]
+workspace = false
+dependencies = ["build_member"]
+condition= {files_modified = {input=["${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
+command = "cp"
+args = ["-r", "${USER_OUTDIR}/echo", "${USER_OUTDIR}/cat", "${USER_OUTDIR}/ls", "${USER_OUTDIR}/xxd", "${FILESYSTEM_PATH}/"]

--- a/userspace/Makefile.toolchain.toml
+++ b/userspace/Makefile.toolchain.toml
@@ -20,4 +20,4 @@ workspace = false
 dependencies = ["build_user_toolchain"]
 cwd = "../extern/rust"
 command = "python"
-args = ["x.py", "install", "rustfmt"]
+args = ["x.py", "install", "rustfmt", "rustc", "library/std"]

--- a/userspace/Makefile.toolchain.toml
+++ b/userspace/Makefile.toolchain.toml
@@ -9,7 +9,7 @@ args = ["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolcha
 
 [tasks.build_user_toolchain]
 workspace = false
-condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/library/std/**"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1/bin/rustc"]}}
+condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/library/std/**/*"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1-std/x86_64-unknown-amjad_os/release/.libstd.stamp"]}}
 dependencies = ["copy_config_toml"]
 cwd = "../extern/rust"
 command = "python"
@@ -17,7 +17,7 @@ args = ["x.py", "build", "-i", "--stage", "1"]
 
 [tasks.install_user_toolchain]
 workspace = false
-condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1/bin/rustc"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/**"]}}
+condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1-std/x86_64-unknown-amjad_os/release/.libstd.stamp"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/*"]}}
 dependencies = ["build_user_toolchain"]
 cwd = "../extern/rust"
 command = "python"

--- a/userspace/Makefile.toolchain.toml
+++ b/userspace/Makefile.toolchain.toml
@@ -1,0 +1,24 @@
+
+[tasks.copy_config_toml]
+workspace = false
+condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/config.toml"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/config.toml"]}}
+cwd = "../extern/rust"
+command = "cp"
+args = ["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/config.toml",
+        "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/config.toml"]
+
+[tasks.build_user_toolchain]
+workspace = false
+condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/library/std/**"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1/bin/rustc"]}}
+dependencies = ["copy_config_toml"]
+cwd = "../extern/rust"
+command = "python"
+args = ["x.py", "build", "-i", "--stage", "1"]
+
+[tasks.install_user_toolchain]
+workspace = false
+condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1/bin/rustc"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/**"]}}
+dependencies = ["build_user_toolchain"]
+cwd = "../extern/rust"
+command = "python"
+args = ["x.py", "install", "-i", "--stage", "1"]

--- a/userspace/Makefile.toolchain.toml
+++ b/userspace/Makefile.toolchain.toml
@@ -9,16 +9,15 @@ args = ["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolcha
 
 [tasks.build_user_toolchain]
 workspace = false
-condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/library/std/**/*"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1-std/x86_64-unknown-amjad_os/release/.libstd.stamp"]}}
+condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/library/std/**/*"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2-std/x86_64-unknown-amjad_os/release/.libstd.stamp"]}}
 dependencies = ["copy_config_toml"]
 cwd = "../extern/rust"
 command = "python"
-args = ["x.py", "build", "-i", "--stage", "1"]
+args = ["x.py", "build", "-i", "--stage", "2", "rustfmt", "library/std"]
 
 [tasks.install_user_toolchain]
 workspace = false
-condition= {files_modified = {input=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage1-std/x86_64-unknown-amjad_os/release/.libstd.stamp"], output=["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/*"]}}
 dependencies = ["build_user_toolchain"]
 cwd = "../extern/rust"
 command = "python"
-args = ["x.py", "install", "-i", "--stage", "1"]
+args = ["x.py", "install", "rustfmt"]

--- a/userspace/init/Cargo.toml
+++ b/userspace/init/Cargo.toml
@@ -6,5 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-std = { path = "../../extern/rust/library/std", default-features = false }
-panic_abort = { path = "../../extern/rust/library/panic_abort" }

--- a/userspace/rust-toolchain.toml
+++ b/userspace/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# a testing toolchain, if you want to get the toolchain installed
+# use `cargo make toolchain`, which will install it in `extern/toolchain`, you can
+# then use `rustup toolchain link <name> ./extern/toolchain` to link it to rustup
+path = "../extern/rust/build/host/stage2"

--- a/userspace/shell/Cargo.toml
+++ b/userspace/shell/Cargo.toml
@@ -26,5 +26,3 @@ name = "xxd"
 path = "src/xxd.rs"
 
 [dependencies]
-std = { path = "../../extern/rust/library/std", default-features = false }
-panic_abort = { path = "../../extern/rust/library/panic_abort" }


### PR DESCRIPTION
The goal of this PR is to eliminate the need to include `std` manually in `userspace` programs.